### PR TITLE
Commit the appcast to the repo and serve the feed from main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,10 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  # Global (not per-tag): two releases in flight would otherwise race to push
+  # appcast.xml to main, and the second push would be rejected as
+  # non-fast-forward.
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -22,6 +25,10 @@ jobs:
         with:
           # Full history so the changelog step can diff between tags
           fetch-depth: 0
+          # Don't persist the GITHUB_TOKEN as an http.extraheader in .git/config;
+          # nothing in this workflow pushes with the token (the appcast push
+          # uses RELEASE_PAT via an inline URL).
+          persist-credentials: false
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
@@ -120,6 +127,18 @@ jobs:
             codesign --force --deep --sign - --entitlements /tmp/release-ents-min.xml "$APP_PATH"
           fi
 
+      - name: Verify release tag matches app version
+        run: |
+          set -euo pipefail
+          APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
+            "build/Build/Products/Release/Holeberry.app/Contents/Info.plist")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$APP_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match app version $APP_VERSION — bump CFBundleShortVersionString in project.yml before tagging"
+            exit 1
+          fi
+          echo "::notice::Tag and app version match ($APP_VERSION)"
+
       - name: Create DMG
         id: dmg
         run: |
@@ -145,7 +164,9 @@ jobs:
           set -euo pipefail
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
           if [ -n "$PREV_TAG" ]; then
-            git log --oneline --no-merges "$PREV_TAG..HEAD" | sed 's/^/- /' > /tmp/changelog.txt
+            # Appcast commits land on main after the tag; exclude them so they
+            # don't show up in the next release's changelog.
+            git log --oneline --no-merges "$PREV_TAG..HEAD" | grep -v "Update appcast for" | sed 's/^/- /' > /tmp/changelog.txt
           else
             echo "- First release." > /tmp/changelog.txt
           fi
@@ -201,11 +222,43 @@ jobs:
               -o build/appcast/appcast.xml \
               build/appcast/
 
-      # The appcast is published as a release asset instead of a commit: the
-      # branch ruleset only allows pushes from the owner, and the GitHub
-      # Actions bot cannot be granted a bypass on personal-account repos. The
-      # feed is served at the stable URL
-      # https://github.com/pedrovieira/Holeberry/releases/latest/download/appcast.xml
+      # Commit the appcast to main with the owner PAT (RELEASE_PAT): the branch
+      # ruleset only allows pushes from the owner, so the Actions bot cannot
+      # push. It is also still attached to the release below so that existing
+      # installs (whose Info.plist points at the /releases/latest/download URL)
+      # keep receiving update checks during the transition to the raw URL.
+      - name: Commit appcast to main
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT secret is not set; cannot commit appcast to main"
+            exit 1
+          fi
+
+          git fetch origin main
+          # The tag checkout leaves us in detached HEAD at the tag commit; reset
+          # to the real tip of main before committing — never push from the tag.
+          git checkout -B main origin/main
+
+          mkdir -p Updates
+          cp build/appcast/appcast.xml Updates/appcast.xml
+
+          git config user.name "Holeberry Release Bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add Updates/appcast.xml
+          if ! git diff --cached --quiet; then
+            # [skip ci] avoids re-running ci.yml/project-drift.yml on main.
+            # The PAT is passed in the push URL only, so it never lands in
+            # .git/config; GitHub masks it in logs, and the repo is public so
+            # the fetch above needs no auth.
+            git commit -m "Update appcast for ${{ github.ref_name }} [skip ci]"
+            git push "https://x-access-token:${RELEASE_PAT}@github.com/${{ github.repository }}.git" main
+          else
+            echo "::notice::appcast.xml unchanged, nothing to commit"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ swift-format lint --recursive --strict Sources/ Packages/HoleberryCore/Sources/
 - **Menu state** — `ServerStatusPoller` (30s default) is the single source of truth; blocking toggles MUST flow through `applyBlockingChange`. Time control is abstracted by `PollScheduler` (`TaskPollScheduler` in prod, `MockPollScheduler` in tests) — no raw `Task.sleep` in production code.
 - **Browser tab detection** — `BrowserTabCoordinator` state machine; Safari/Chromium via AppleScript (`-1743` error = permission denied), Firefox/Zen via `sessionstore.jsonlz4` parsing; permission checks via Carbon `AEDeterminePermissionToAutomateTarget`. Keep the strategy seams (`BrowserActiveUrlFetchingStrategyFactory`).
 - **Persistence** — typed `Defaults` keys centralized in `HoleberryCore/Utils/App+Defaults.swift`; secrets via `KeychainManager` (keyed by server UUID) — never plaintext on disk.
-- **Updates** — Sparkle; `appcast.xml` is generated in CI and published as a release asset (feed URL: `https://github.com/pedrovieira/Holeberry/releases/latest/download/appcast.xml`), not committed — the branch ruleset only allows pushes from the owner.
+- **Updates** — Sparkle; `appcast.xml` is generated in CI, committed to `main` via the owner PAT (`RELEASE_PAT` secret — the branch ruleset only allows pushes from the owner, so `GITHUB_TOKEN` can't push), and still attached to the release as a transition fallback for existing installs. Feed URL (set in `project.yml`, regenerated into `Info.plist` by XcodeGen): `https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Updates/appcast.xml`.
 - **Server limits** — max 2 servers (`PiholeServerManager`).
 
 ## Conventions
@@ -65,7 +65,7 @@ swift-format lint --recursive --strict Sources/ Packages/HoleberryCore/Sources/
 - PRs target `main`. Open an issue first for substantial work (per README).
 - AI-assisted contributions are welcome — this project is itself AI-assisted (see the README's "AI-assisted development" section). PRs produced with AI assistance MUST disclose it in the PR description, including which tool/model was used.
 - README exists in en / zh-CN / ja — doc changes should update all three, or note that translation is pending.
-- Release: tagging `v*` triggers `.github/workflows/release.yml` (build → DMG → GitHub Release with DMG + signed appcast assets).
+- Release: tagging `v*` triggers `.github/workflows/release.yml` (build → tag/version consistency check → DMG → appcast committed to `main` via `RELEASE_PAT` → GitHub Release with DMG + appcast assets).
 
 ## Notes
 

--- a/Sources/Holeberry/Support/Info.plist
+++ b/Sources/Holeberry/Support/Info.plist
@@ -31,7 +31,7 @@
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://github.com/pedrovieira/Holeberry/releases/latest/download/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Updates/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>xqSTVnKmoOX+TbqHndinP0cEITTAKsrSGjnOFZO0TlM=</string>
 </dict>

--- a/Updates/appcast.xml
+++ b/Updates/appcast.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+<channel>
+<title>Holeberry</title>
+<description>Most recent changes with links to updates.</description>
+<language>en</language>
+<item>
+<title>1.0.0</title>
+<pubDate>Thu, 13 Aug 2026 11:14:46 +0000</pubDate>
+<sparkle:version>1.0.0</sparkle:version>
+<sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
+<sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+<enclosure url="https://github.com/pedrovieira/Holeberry/releases/download/v1.0.1/Holeberry-1.0.1.dmg" length="6945182" type="application/octet-stream" sparkle:edSignature="/OK/9mRpnmPIVhKluGAhtl00jt1Dn9tM5kynzUqoxRTuGqJtd8qyUqFTet7rSU/ewJhmL95d1KAmIor5uO4yBg=="/>
+</item>
+</channel>
+</rss>

--- a/project.yml
+++ b/project.yml
@@ -41,7 +41,7 @@ targets:
         NSAppleEventsUsageDescription: Holeberry needs to read the current tab URL from your browser to unblock it.
         SUEnableDownloaderService: true
         SUEnableInstallerLauncherService: true
-        SUFeedURL: "https://github.com/pedrovieira/Holeberry/releases/latest/download/appcast.xml"
+        SUFeedURL: "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Updates/appcast.xml"
         SUPublicEDKey: "xqSTVnKmoOX+TbqHndinP0cEITTAKsrSGjnOFZO0TlM="
     settings:
       base:


### PR DESCRIPTION
## Problem

The Sparkle appcast was only published as a GitHub **release asset** and served from `releases/latest/download/appcast.xml`. That worked, but it kept the feed out of version control, and it was impossible to drop the asset without breaking every installed copy (`Info.plist` points at the asset URL).

There was also a versioning mismatch in the last release: the appcast item said **1.0.0** while the DMG it pointed to was **1.0.1** (`generate_appcast` reads the version from the built app, but the download URL comes from the tag — the tag was bumped without bumping the app version).

## Changes

- **`.github/workflows/release.yml`**
  - New **"Commit appcast to main"** step: pushes `Updates/appcast.xml` to `main` via the owner PAT (`RELEASE_PAT` secret). The branch ruleset only bypasses the owner, so `GITHUB_TOKEN` can't push — the PAT is required. Detached-HEAD-safe (`git fetch origin main && git checkout -B main origin/main`), empty-commit guard, `[skip ci]` so the push doesn't re-trigger CI.
  - New **"Verify release tag matches app version"** guard: the release fails if `GITHUB_REF_NAME` doesn't match `CFBundleShortVersionString` from the built app, so the appcast version and DMG URL can't diverge again.
  - Changelog filter for appcast commits, global concurrency group (no push races between back-to-back tags), `persist-credentials: false`, and the PAT is passed in the push URL only — never written to `.git/config`.
  - The appcast **stays attached** to the release for now (transition fallback, see below).
- **`project.yml` / `Info.plist`** — `SUFeedURL` moved to `https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Updates/appcast.xml` (project.yml is the source of truth; plist regenerated with `xcodegen`, zero `project.pbxproj` drift).
- **`Updates/appcast.xml`** — new seed file with a single 1.0.0 item whose download link points at the **v1.0.1** release (`Holeberry-1.0.1.dmg`, verified against the release asset API: exists, size matches `length`).
- **`CLAUDE.md`** — agent guidance updated to match the new flow.

## Transition plan

Old installs have the asset URL baked in, so the appcast is **still attached** to releases until everyone is on a build with the new feed URL; then it can be dropped from the release `files:` list. Next release: bump `project.yml` to 1.0.2 and tag `v1.0.2` — the new guard enforces the match.

## Verification

- `xcodegen generate` → only the SUFeedURL string changes; the drift check stays green
- YAML parses; `Info.plist` passes `plutil -lint`; appcast is well-formed XML
- Enclosure URL/size verified against the real `v1.0.1` release
- `RELEASE_PAT` confirmed present as an Actions secret; ruleset bypass confirmed via API (owner-only bypass actor)

## AI assistance

Prepared with the Reasonix coding agent; reviewed and directed by the repo owner.