### PR TITLE
fix: use legacy keychain for ad-hoc builds and surface missing credentials

### DIFF
--- a/Packages/HoleberryCore/Sources/HoleberryCore/Models/ServerConnectionState.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Models/ServerConnectionState.swift
@@ -9,6 +9,7 @@ public enum ServerConnectionState: Equatable, Sendable {
 
 /// Why authentication failed. An enum — not copy — so labels stay localizable.
 public enum AuthFailureReason: Equatable, Sendable {
+  case missingCredential
   case passwordMayHaveChanged
   case authenticationFailed
   case totpRequired
@@ -26,6 +27,8 @@ public enum ServerCheckFailure: Equatable, Sendable {
     switch error {
     case .invalidCredentials, .reauthenticationFailed:
       return .auth(.passwordMayHaveChanged)
+    case .missingCredential:
+      return .auth(.missingCredential)
     case .unauthorized:
       return .auth(.authenticationFailed)
     case .server(let code, _) where code == 401:

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Persistence/KeychainManager.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Persistence/KeychainManager.swift
@@ -19,14 +19,9 @@ public final class KeychainManager: KeychainManaging {
     let context = LAContext()
     context.localizedReason = "Holeberry needs to access your saved Pi-hole password."
 
-    let attributes: [String: Any] = [
-      kSecUseDataProtectionKeychain as String: true
-    ]
     self.keychain = SimpleKeychain(
       service: Bundle.main.bundleIdentifier ?? "me.pedrovieira.holeberry",
-      accessibility: .afterFirstUnlock,
-      context: context,
-      attributes: attributes
+      context: context
     )
   }
 

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeError.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeError.swift
@@ -10,6 +10,7 @@ public enum PiholeError: Error, LocalizedError, Equatable {
   case decoding(String)
   case totpRequired
   case invalidCredentials
+  case missingCredential
   case rateLimited
   case reauthenticationFailed
   case sessionLimitReached
@@ -36,6 +37,8 @@ public enum PiholeError: Error, LocalizedError, Equatable {
       return "TOTP code required for 2FA"
     case .invalidCredentials:
       return "Invalid Pi-hole password or application password."
+    case .missingCredential:
+      return "No saved credential for this server."
     case .rateLimited:
       return "Login rate limited. Please wait before trying again."
     case .reauthenticationFailed:

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeServerManager.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeServerManager.swift
@@ -58,11 +58,11 @@ public final class PiholeServerManager: PiholeServerManaging, ObservableObject {
 
     try await service.login()
 
+    try keychain.saveCredential(credential, for: config.id)
+
     servers.append(config)
     services[config.id] = service
     saveServers()
-
-    try keychain.saveCredential(credential, for: config.id)
 
     logger.info("Added server: \(config.label ?? config.url, privacy: .public)")
   }
@@ -235,8 +235,30 @@ public final class PiholeServerManager: PiholeServerManaging, ObservableObject {
       return .success(status)
     } catch {
       let piholeError = error as? PiholeError ?? PiholeError.unknown(error.localizedDescription)
+      if isCredentialFailure(piholeError) && !hasStoredCredential(id: id) {
+        // No saved credential (never stored, or the keychain is unreadable):
+        // surface "re-authenticate" instead of "password may have changed".
+        return .failure(.missingCredential)
+      }
       return .failure(piholeError)
     }
+  }
+
+  /// Whether the error means "the credential we tried was rejected" (as
+  /// opposed to TOTP, rate limiting, or network problems).
+  private func isCredentialFailure(_ error: PiholeError) -> Bool {
+    switch error {
+    case .invalidCredentials, .unauthorized:
+      return true
+    case .server(let code, _) where code == 401:
+      return true
+    default:
+      return false
+    }
+  }
+
+  private func hasStoredCredential(id: UUID) -> Bool {
+    (try? keychain.readCredential(for: id)) != nil
   }
 
   /// Toggle blocking on all servers. Returns per-server success/failure.
@@ -492,9 +514,12 @@ public final class PiholeServerManager: PiholeServerManaging, ObservableObject {
     servers = configs
 
     for config in servers {
-      guard let credential = try? keychain.readCredential(for: config.id) else {
-        logger.warning("No credential found for server \(config.id), skipping")
-        continue
+      // Build the service even without a stored credential (using an empty
+      // one): the health check then fails as an auth error and the UI can
+      // offer a "Re-authenticate" affordance instead of "unreachable".
+      let credential = (try? keychain.readCredential(for: config.id)) ?? ""
+      if credential.isEmpty {
+        logger.warning("No credential found for server \(config.id), will prompt to re-authenticate")
       }
       guard let serverURL = URL(string: config.url) else { continue }
       let session = makeSession(trusting: serverURL)

--- a/Packages/HoleberryCore/Tests/HoleberryCoreTests/Models/ServerConnectionStateTests.swift
+++ b/Packages/HoleberryCore/Tests/HoleberryCoreTests/Models/ServerConnectionStateTests.swift
@@ -22,6 +22,7 @@ struct ServerCheckFailureTests {
     #expect(ServerCheckFailure.classify(.totpRequired) == .auth(.totpRequired))
     #expect(ServerCheckFailure.classify(.rateLimited) == .auth(.rateLimited))
     #expect(ServerCheckFailure.classify(.sessionLimitReached) == .auth(.sessionLimitReached))
+    #expect(ServerCheckFailure.classify(.missingCredential) == .auth(.missingCredential))
   }
 
   @Test("everything else is unreachable")

--- a/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/Pihole/PiholeServerManagerTests.swift
+++ b/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/Pihole/PiholeServerManagerTests.swift
@@ -91,6 +91,78 @@ struct PiholeServerManagerCRUDTests {
     #expect(manager.servers.count == 2)
   }
 
+  @Test("addServer registers server and stores credential in keychain")
+  func addServerSuccess() async throws {
+    let manager = makeManager(suite: TestDefaults.makeSuite())
+    try await manager.addServer(label: "Test", url: "http://test.com", credential: "secret")
+
+    #expect(manager.servers.count == 1)
+    #expect(manager.servers[0].label == "Test")
+    #expect(manager.servers[0].version == .v6)
+    #expect(mockKeychain.storedCredentials[manager.servers[0].id.uuidString] == "secret")
+    #expect(mockServiceFactory.buildServiceCallCount == 1)
+  }
+
+  @Test("addServer throws and leaves nothing registered when keychain save fails")
+  func addServerKeychainFailureLeavesNoPartialState() async {
+    let suite = TestDefaults.makeSuite()
+    let manager = makeManager(suite: suite)
+    mockKeychain.errorStub = PiholeError.unknown("keychain unavailable")
+    defer { mockKeychain.errorStub = nil }
+
+    await #expect(throws: PiholeError.self) {
+      try await manager.addServer(label: "Test", url: "http://test.com", credential: "secret")
+    }
+    #expect(manager.servers.isEmpty)
+    #expect(Defaults[.servers(suite: suite)].isEmpty)
+  }
+
+  @Test("loadServers builds a service even without a stored credential")
+  func loadServersBuildsServiceWithoutCredential() {
+    let suite = TestDefaults.makeSuite()
+    let config = ServerConfig(label: "Test", url: "http://test.com", version: .v6)
+    Defaults[.servers(suite: suite)] = [config]
+
+    _ = makeManager(suite: suite)
+
+    #expect(mockServiceFactory.buildServiceCallCount == 1, "service must be built so the UI can offer re-auth")
+  }
+
+  @Test("checkServer reports missingCredential when no credential is stored")
+  func checkServerReportsMissingCredentialWhenNoneStored() async {
+    let suite = TestDefaults.makeSuite()
+    let config = ServerConfig(label: "Test", url: "http://test.com", version: .v6)
+    Defaults[.servers(suite: suite)] = [config]
+
+    let failingService = MockPiholeService(id: config.id, url: config.url, version: .v6)
+    failingService.checkStatusStub = .failure(PiholeError.invalidCredentials)
+    mockServiceFactory.buildServiceStub = failingService
+    defer { mockServiceFactory.buildServiceStub = nil }
+
+    let manager = makeManager(suite: suite)
+    let result = await manager.checkServer(id: config.id)
+
+    #expect(result == .failure(.missingCredential))
+  }
+
+  @Test("checkServer keeps invalidCredentials when a credential is stored")
+  func checkServerKeepsInvalidCredentialsWhenStored() async {
+    let suite = TestDefaults.makeSuite()
+    let config = ServerConfig(label: "Test", url: "http://test.com", version: .v6)
+    Defaults[.servers(suite: suite)] = [config]
+    try? mockKeychain.saveCredential("old-password", for: config.id)
+
+    let failingService = MockPiholeService(id: config.id, url: config.url, version: .v6)
+    failingService.checkStatusStub = .failure(PiholeError.invalidCredentials)
+    mockServiceFactory.buildServiceStub = failingService
+    defer { mockServiceFactory.buildServiceStub = nil }
+
+    let manager = makeManager(suite: suite)
+    let result = await manager.checkServer(id: config.id)
+
+    #expect(result == .failure(.invalidCredentials))
+  }
+
   private func makeManagerWithLoadedService(suite: UserDefaults) -> PiholeServerManager {
     let config = ServerConfig(label: "Test", url: "http://test.com", version: .v6)
     Defaults[.servers(suite: suite)] = [config]

--- a/Sources/Holeberry/Settings/ConnectionViews/AuthFailureReason+Copy.swift
+++ b/Sources/Holeberry/Settings/ConnectionViews/AuthFailureReason+Copy.swift
@@ -7,6 +7,8 @@ extension AuthFailureReason {
     switch self {
     case .passwordMayHaveChanged:
       return String(localized: "Password may have changed")
+    case .missingCredential:
+      return String(localized: "No saved credential")
     case .authenticationFailed:
       return String(localized: "Authentication failed")
     case .totpRequired:

--- a/Sources/Holeberry/Settings/ConnectionViews/ConnectionSheet.swift
+++ b/Sources/Holeberry/Settings/ConnectionViews/ConnectionSheet.swift
@@ -120,7 +120,8 @@ struct ConnectionSheet: View {
     if case .edit = mode {
       let labelChanged = label != (mode.existingLabel ?? "")
       let iconChanged = iconName != (mode.existingIcon ?? "")
-      return baseValid && (labelChanged || iconChanged)
+      let urlChanged = url.trimmingCharacters(in: .whitespaces) != mode.prefillURL
+      return baseValid && (labelChanged || iconChanged || urlChanged || !credential.isEmpty)
     }
     return baseValid && !credential.isEmpty
   }


### PR DESCRIPTION
## Summary

Fixes #2 — **"errSecMissingEntitlement on successful connection"**. Adding a Pi-hole server on the released (ad-hoc-signed) app failed with `-34018` at the moment the credential was saved to the Keychain, even though the connection itself succeeded.

**Root cause:** `KeychainManager` used the Data Protection keychain (`kSecUseDataProtectionKeychain`), which requires a valid code signature carrying an `application-identifier` entitlement. The GitHub release is ad-hoc signed (no signing secrets configured in CI), so `securityd` rejects every Keychain write with `errSecMissingEntitlement`. Xcode dev builds work because they're signed with a (free) personal team.

## Changes

**Keychain storage — works for both ad-hoc and properly signed builds**
- `KeychainManager`: drop `kSecUseDataProtectionKeychain` and store credentials in the legacy keychain (verified: legacy keychain works fine for ad-hoc-signed processes; `kSecAttrAccessible` is ignored on macOS legacy keychains)
- `PiholeServerManager.addServer`: persist the credential **before** registering the server, so a Keychain failure can no longer leave a partially-created server (config saved, password missing) — the confusing "creation failed but it connected" state from the issue

**Missing-credential handling — "Re-authenticate" instead of "unreachable"**
- `loadServers`: build a service even when no credential is stored (empty credential), so the poller classifies the failure as an auth error and the UI offers **Re-authenticate** instead of the Retry/"Fix" unreachable loop
- `checkServer`: reports the new `PiholeError.missingCredential` when an auth failure occurs and no credential is stored (distinct from a wrong stored password → still "Password may have changed"; TOTP/rate-limit/session-limit/network classifications unchanged)
- New `AuthFailureReason.missingCredential` + copy: card shows **"No saved credential"** with the Re-authenticate button

**Edit sheet dead-end fix**
- `ConnectionSheet.canCreate` (edit mode): Submit now also enables when the URL changed or a credential was entered (previously only label/icon changes enabled it, so "Fix" on an unreachable server could never be submitted)

## Testing

- `swift test`: 358 tests in 46 suites pass, including new coverage:
  - keychain-failure rollback in `addServer` (no partial state in memory or defaults)
  - service built for persisted configs without a credential
  - `checkServer` remaps to `.missingCredential` only when nothing is stored
  - classification of the new error
- `swiftlint --strict`: 0 violations; `swift-format` strict: clean
- Manual: ad-hoc Release build + DMG (same signing recipe as CI) — server without credential shows "No saved credential → Re-authenticate"; re-authenticating connects immediately without relaunch

## Known trade-off (ad-hoc releases only)

Because ad-hoc signatures are cdhash-bound, users of ad-hoc releases will see a **one-time Keychain "Allow Holeberry…?" prompt after each app update** when reading their saved credential. Clicking Allow is all that's needed; this disappears once releases are Developer ID-signed (paid account).
