### PR TITLE
ci: use GitHub-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Full history so the changelog step can diff between tags
+          # Full history: the appcast step resets local main from origin/main.
           fetch-depth: 0
           # Don't persist the GITHUB_TOKEN as an http.extraheader in .git/config;
           # nothing in this workflow pushes with the token (the appcast push
@@ -158,24 +158,6 @@ jobs:
           echo "dmg_path=$DMG_PATH" >> "$GITHUB_OUTPUT"
           echo "dmg_name=$DMG_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Generate changelog
-        id: changelog
-        run: |
-          set -euo pipefail
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
-          if [ -n "$PREV_TAG" ]; then
-            # Appcast commits land on main after the tag; exclude them so they
-            # don't show up in the next release's changelog.
-            git log --oneline --no-merges "$PREV_TAG..HEAD" | grep -v "Update appcast for" | sed 's/^/- /' > /tmp/changelog.txt
-          else
-            echo "- First release." > /tmp/changelog.txt
-          fi
-          {
-            echo "body<<EOF"
-            cat /tmp/changelog.txt
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Clone Sparkle (matching pinned version)
         run: |
           set -euo pipefail
@@ -265,5 +247,7 @@ jobs:
           files: |
             ${{ steps.dmg.outputs.dmg_path }}
             build/appcast/appcast.xml
-          body: ${{ steps.changelog.outputs.body }}
+          # GitHub generates notes server-side (PRs + contributors); no local
+          # tag math, so it survives rewritten tags.
+          generate_release_notes: true
           make_latest: true


### PR DESCRIPTION
## Problem

The v1.0.2 release changelog was generated as `- First release.` instead of the actual commits. The custom "Generate changelog" step relied on `git describe --tags --abbrev=0 HEAD^`, which found no previous tag in CI:

- the `v1.0.0` tag does not exist on the remote (deleted together with the release), and
- `v1.0.1` points at a commit that was rewritten away, so it is not an ancestor of the new tag.

The fallback branch then produced `- First release.` (you can see `body: - First release.` in the v1.0.2 workflow run log).

## Fix

Replace the local `git log`-based changelog with GitHub's server-side generated release notes (`generate_release_notes: true` on `softprops/action-gh-release`):

- notes are computed by GitHub itself (no local tag math, so it survives rewritten tags),
- each merged PR becomes one line with author attribution, plus a "New Contributors" section when applicable,
- direct commits (e.g. the appcast `[skip ci]` commits) are not listed, so the previous `grep -v` hack is no longer needed.

Kept `fetch-depth: 0`: the "Commit appcast to main" step resets a local `main` from `refs/remotes/origin/*`, which a shallow tag checkout may not provide.

Verified via the `generate_release_notes` API that `v1.0.3`'s notes resolve correctly against `v1.0.2` (`compare/v1.0.2...v1.0.3`), while `v1.0.2` itself cannot produce a proper diff because its history shares no common ancestor with `v1.0.1`.