### PR TITLE
ci: merge release entries into the committed appcast feed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,20 +189,29 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
+      - name: Switch to latest main
+        run: |
+          set -euo pipefail
+          # The tag checkout is detached at the tag commit; base the merge on real main.
+          git fetch origin main
+          git checkout -B main origin/main
+
       - name: Generate signed appcast
         env:
           PRIVATE_SPARKLE_KEY: ${{ secrets.PRIVATE_SPARKLE_KEY }}
         run: |
           set -euo pipefail
-          mkdir -p build/appcast
-          cp "${{ steps.dmg.outputs.dmg_path }}" build/appcast/
+          mkdir -p Updates
+          cp "${{ steps.dmg.outputs.dmg_path }}" Updates/
 
+          # Merges into the existing feed at -o: older entries are kept,
+          # same-version entries are replaced.
           printf '%s' "$PRIVATE_SPARKLE_KEY" | \
             /tmp/sparkle-derived/Build/Products/Release/generate_appcast \
               --ed-key-file - \
               --download-url-prefix "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/" \
-              -o build/appcast/appcast.xml \
-              build/appcast/
+              -o Updates/appcast.xml \
+              Updates/
 
       # Commit the appcast to main with the owner PAT (RELEASE_PAT): the branch
       # ruleset only allows pushes from the owner, so the Actions bot cannot
@@ -219,14 +228,6 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main
-          # The tag checkout leaves us in detached HEAD at the tag commit; reset
-          # to the real tip of main before committing — never push from the tag.
-          git checkout -B main origin/main
-
-          mkdir -p Updates
-          cp build/appcast/appcast.xml Updates/appcast.xml
-
           git config user.name "Holeberry Release Bot"
           git config user.email "actions@users.noreply.github.com"
           git add Updates/appcast.xml
@@ -234,7 +235,7 @@ jobs:
             # [skip ci] avoids re-running ci.yml/project-drift.yml on main.
             # The PAT is passed in the push URL only, so it never lands in
             # .git/config; GitHub masks it in logs, and the repo is public so
-            # the fetch above needs no auth.
+            # reads need no auth.
             git commit -m "Update appcast for ${{ github.ref_name }} [skip ci]"
             git push "https://x-access-token:${RELEASE_PAT}@github.com/${{ github.repository }}.git" main
           else
@@ -246,7 +247,7 @@ jobs:
         with:
           files: |
             ${{ steps.dmg.outputs.dmg_path }}
-            build/appcast/appcast.xml
+            Updates/appcast.xml
           # GitHub generates notes server-side (PRs + contributors); no local
           # tag math, so it survives rewritten tags.
           generate_release_notes: true


### PR DESCRIPTION
## Problem

The committed `Updates/appcast.xml` feed gets **overwritten** with a single-item appcast on every release instead of accumulating entries.

Sparkle's `generate_appcast` merges new items into an existing appcast at the `-o` path (it reads the file, updates same-version entries, keeps older ones). The v1.0.1-era workflow generated directly into `Updates/`, so the v1.0.1 entry was **appended** (commit `907d0d5`: +8 lines, old entry kept; run log: "Wrote 1 new update, updated 0 existing updates").

Commit `ba83d74` moved generation to a fresh `build/appcast/` directory (so the file could also be attached to the release) and then `cp`-overwrote `Updates/appcast.xml`. The v1.0.2 run then replaced the whole feed: commit `a0752e9` (+14/−16), and the current `Updates/appcast.xml` contains only the 1.0.2 entry — the v1.0.1 entry is gone.

## Fix

Generate the appcast directly into `Updates/` again, restoring Sparkle's native merge:

- new **"Switch to latest main"** step (moved out of the commit step) — the merge must base on the real tip of `main`, not the detached tag checkout;
- "Generate signed appcast" now writes `Updates/appcast.xml` with `generate_appcast -o Updates/appcast.xml Updates/`, so new entries are merged into the committed feed (older entries kept, same-version replaced, feed trimmed to the ~5 newest versions by Sparkle);
- "Commit appcast to main" only stages/commits/pushes `Updates/appcast.xml` (the DMG stays untracked);
- the release asset is now the same merged feed (`Updates/appcast.xml`) — existing installs pointing at `/releases/latest/download/appcast.xml` still get a valid feed with the latest version.

Not restored: the lost v1.0.1 entry — it was generated with a version/tag mismatch (`sparkle:version` 1.0.0 with a v1.0.1 URL) and is still reachable in git history if ever needed.

## Verification

- Sparkle 2.9.4 source: `writeAppcast` reads the existing appcast at the destination and merges items by `sparkle:version`.
- The exact generation command here (`-o Updates/appcast.xml Updates/` with an existing file) is what produced the append in the v1.0.1 run.