### PR TITLE
ci: notarized Developer ID releases with in-app Sparkle updates

### DIFF
--- a/.github/workflows/project-drift.yml
+++ b/.github/workflows/project-drift.yml
@@ -22,7 +22,8 @@ jobs:
     # the secret-backed run on same-repo pushes.
     env:
       HOLEBERRY_TEAM_ID: ${{ secrets.HOLEBERRY_TEAM_ID || '5UN5GTF749' }}
-      HOLEBERRY_CODE_SIGN_IDENTITY: ${{ secrets.HOLEBERRY_CODE_SIGN_IDENTITY || 'Apple Development' }}
+      # Quoted: the fallback contains ": " which is invalid YAML in a plain scalar
+      HOLEBERRY_CODE_SIGN_IDENTITY: "${{ secrets.HOLEBERRY_CODE_SIGN_IDENTITY || 'Developer ID Application: Pedro Vieira (5UN5GTF749)' }}"
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,28 @@ jobs:
             -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list \
             -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # Fail fast: a certificate-only p12 imports fine but leaves no signing
+          # identity — the release would otherwise die later with a cryptic
+          # SecItemCopyMatching error at the first codesign.
+          if security find-identity -v -p codesigning "$KEYCHAIN" 2>/dev/null | grep -q "0 valid identities"; then
+            echo "::error::HOLEBERRY_CERT_P12 contains no private key — re-export the p12 from Keychain Access (My Certificates) with the private key included"
+            exit 1
+          fi
           security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
           echo "::notice::Signing certificate imported into $KEYCHAIN"
+
+      - name: Prepare notarization credentials
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$APPLE_API_KEY" ]; then
+            echo "::notice::No App Store Connect API key secret; skipping notarization"
+            exit 0
+          fi
+          # App Store Connect API key (.p8), base64-encoded in the secret.
+          echo "$APPLE_API_KEY" | base64 --decode > /tmp/holeberry-apple-api-key.p8
+          echo "::notice::App Store Connect API key written"
 
       - name: Build Holeberry
         env:
@@ -86,8 +106,17 @@ jobs:
           APP_PATH="build/Build/Products/Release/Holeberry.app"
 
           if [ -n "$HOLEBERRY_CERT_P12" ]; then
-            # Real signing with the certificate imported above (Apple Development
-            # or Developer ID). Restricted entitlements are fine here.
+            # Real signing with the Developer ID Application certificate imported
+            # above — required for notarized distribution outside the Mac App
+            # Store.
+            #
+            # CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO: Xcode 26 injects the
+            # restricted com.apple.security.get-task-allow entitlement into
+            # Release builds (even with a Developer ID identity) whenever
+            # base-entitlement injection is on and no provisioning profile is
+            # in play. The notary service rejects restricted entitlements, so
+            # we disable the injection — our own entitlements file is all the
+            # app needs.
             echo "::notice::Signing with identity $HOLEBERRY_CODE_SIGN_IDENTITY"
             xcodebuild -project Holeberry.xcodeproj \
               -scheme Holeberry \
@@ -98,6 +127,7 @@ jobs:
               CODE_SIGN_STYLE=Manual \
               CODE_SIGNING_REQUIRED=YES \
               CODE_SIGNING_ALLOWED=YES \
+              CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
               DEVELOPMENT_TEAM="$HOLEBERRY_TEAM_ID" \
               CODE_SIGN_IDENTITY="$HOLEBERRY_CODE_SIGN_IDENTITY"
           else
@@ -127,6 +157,47 @@ jobs:
             codesign --force --deep --sign - --entitlements /tmp/release-ents-min.xml "$APP_PATH"
           fi
 
+      - name: Re-sign nested Sparkle code
+        env:
+          HOLEBERRY_CERT_P12: ${{ secrets.HOLEBERRY_CERT_P12 }}
+          HOLEBERRY_CODE_SIGN_IDENTITY: ${{ secrets.HOLEBERRY_CODE_SIGN_IDENTITY }}
+          HOLEBERRY_TEAM_ID: ${{ secrets.HOLEBERRY_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HOLEBERRY_CERT_P12" ]; then
+            echo "::notice::No signing certificate secret; skipping nested re-sign (ad-hoc path)"
+            exit 0
+          fi
+          APP_PATH="build/Build/Products/Release/Holeberry.app"
+          SPARKLE_FW="$APP_PATH/Contents/Frameworks/Sparkle.framework/Versions/Current"
+          # Sparkle's XCFramework ships its XPC services and helper binaries
+          # ad-hoc signed; Xcode re-signs the framework but not its contents.
+          # The notary service rejects ad-hoc nested code, so re-sign
+          # inside-out with the Developer ID identity, preserving each item's
+          # own entitlements.
+          for item in \
+            "$SPARKLE_FW/XPCServices/Downloader.xpc" \
+            "$SPARKLE_FW/XPCServices/Installer.xpc" \
+            "$SPARKLE_FW/Updater.app" \
+            "$SPARKLE_FW/Autoupdate"; do
+            codesign --force --options runtime --preserve-metadata=entitlements,identifier \
+              --sign "$HOLEBERRY_CODE_SIGN_IDENTITY" "$item"
+          done
+          codesign --force --options runtime --preserve-metadata=entitlements,identifier \
+            --sign "$HOLEBERRY_CODE_SIGN_IDENTITY" "$SPARKLE_FW"
+          codesign --force --options runtime --preserve-metadata=entitlements,identifier \
+            --sign "$HOLEBERRY_CODE_SIGN_IDENTITY" "$APP_PATH"
+          # Audit: every Mach-O in the bundle must carry our team ID
+          find "$APP_PATH" -type f -exec file {} \; | grep "Mach-O" | grep -v "for architecture" | cut -d: -f1 | while read -r f; do
+            # Plain grep (not grep -q): grep -q exits early and SIGPIPEs
+            # codesign, which pipefail then reports as a false failure.
+            if ! codesign -dv "$f" 2>&1 | grep "TeamIdentifier=$HOLEBERRY_TEAM_ID" >/dev/null; then
+              echo "::error::$f is not signed with team $HOLEBERRY_TEAM_ID"
+              exit 1
+            fi
+          done
+          echo "::notice::Nested Sparkle code re-signed and audited"
+
       - name: Verify release tag matches app version
         run: |
           set -euo pipefail
@@ -138,6 +209,46 @@ jobs:
             exit 1
           fi
           echo "::notice::Tag and app version match ($APP_VERSION)"
+
+      - name: Notarize app
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/holeberry-apple-api-key.p8 ]; then
+            echo "::notice::Notarization credentials not configured; skipping app notarization"
+            exit 0
+          fi
+          APP_PATH="build/Build/Products/Release/Holeberry.app"
+          # Fail fast on a bad signature before spending minutes in the notary queue
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          # notarytool requires a container format (.zip/.pkg/.dmg) and rejects a
+          # bare .app; zip the app, then staple the ticket onto the bundle itself.
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" /tmp/holeberry-app.zip
+          # notarytool exits 0 even when Apple's verdict is "Invalid", so check
+          # the status ourselves and print Apple's log on rejection.
+          SUBMIT_OUTPUT="$(xcrun notarytool submit /tmp/holeberry-app.zip \
+            --key /tmp/holeberry-apple-api-key.p8 \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait \
+            --timeout 30m 2>&1 || true)"
+          echo "$SUBMIT_OUTPUT"
+          if ! echo "$SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
+            SUBMISSION_ID="$(echo "$SUBMIT_OUTPUT" | sed -n 's/.*id: \([0-9a-f-]\{36\}\).*/\1/p' | head -1)"
+            if [ -n "$SUBMISSION_ID" ]; then
+              echo "::error::Notarization rejected — Apple's log:"
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --key /tmp/holeberry-apple-api-key.p8 \
+                --key-id "$APPLE_API_KEY_ID" \
+                --issuer "$APPLE_API_ISSUER_ID" || true
+            fi
+            exit 1
+          fi
+          # Staple before packaging so the ticket is embedded in the DMG
+          xcrun stapler staple "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
 
       - name: Create DMG
         id: dmg
@@ -157,6 +268,37 @@ jobs:
 
           echo "dmg_path=$DMG_PATH" >> "$GITHUB_OUTPUT"
           echo "dmg_name=$DMG_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Notarize DMG
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/holeberry-apple-api-key.p8 ]; then
+            echo "::notice::Notarization credentials not configured; skipping DMG notarization"
+            exit 0
+          fi
+          SUBMIT_OUTPUT="$(xcrun notarytool submit "${{ steps.dmg.outputs.dmg_path }}" \
+            --key /tmp/holeberry-apple-api-key.p8 \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait \
+            --timeout 30m 2>&1 || true)"
+          echo "$SUBMIT_OUTPUT"
+          if ! echo "$SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
+            SUBMISSION_ID="$(echo "$SUBMIT_OUTPUT" | sed -n 's/.*id: \([0-9a-f-]\{36\}\).*/\1/p' | head -1)"
+            if [ -n "$SUBMISSION_ID" ]; then
+              echo "::error::DMG notarization rejected — Apple's log:"
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --key /tmp/holeberry-apple-api-key.p8 \
+                --key-id "$APPLE_API_KEY_ID" \
+                --issuer "$APPLE_API_ISSUER_ID" || true
+            fi
+            exit 1
+          fi
+          xcrun stapler staple "${{ steps.dmg.outputs.dmg_path }}"
+          xcrun stapler validate "${{ steps.dmg.outputs.dmg_path }}"
 
       - name: Clone Sparkle (matching pinned version)
         run: |

--- a/Holeberry.xcodeproj/project.pbxproj
+++ b/Holeberry.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application: Pedro Vieira (5UN5GTF749)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 5UN5GTF749;
@@ -493,6 +493,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/Holeberry/Support/Holeberry.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Sources/Holeberry/Support/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -537,7 +538,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application: Pedro Vieira (5UN5GTF749)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 5UN5GTF749;
@@ -570,6 +571,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/Holeberry/Support/Holeberry.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Sources/Holeberry/Support/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,11 +35,7 @@ Pi-hole® **v6** と **v5**（*完全にはテストされていません*）、
 1. [Releases](https://github.com/pedrovieira/Holeberry/releases) ページから最新の `Holeberry-<バージョン>.dmg` をダウンロードします。
 2. DMG を開き、**Holeberry** を `Applications` フォルダにドラッグします。
 
-**macOS Gatekeeper についての注意：** Holeberry は無料の Apple ID でビルドされており、有料の Apple Developer アカウントによる公証（notarization）を受けていません。そのため、macOS が「開発元不明のアプリ」として警告したり、初回起動時に隔離したりする場合があります。その警告が表示されたら、隔離フラグを削除して再度起動してください：
-
-```bash
-xattr -cr /Applications/Holeberry.app
-```
+**macOS Gatekeeper についての注意：** Holeberry は Developer ID で署名され、Apple による公証（notarization）済みです。macOS が「開発元不明のアプリ」として警告することはありません。
 
 ## 動作環境
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,7 @@ It supports Pi-hole® **v6** and **v5** (*not fully tested*), multiple instances
 1. Download the latest `Holeberry-<version>.dmg` from the [Releases](https://github.com/pedrovieira/Holeberry/releases) page.
 2. Open the DMG and drag **Holeberry** into your `Applications` folder.
 
-**Note on macOS Gatekeeper:** Holeberry is built with a free Apple ID, so the app is not notarized with a paid Apple Developer account. macOS may therefore flag it as an unidentified developer or quarantine it on first launch. If you see that warning, remove the quarantine flag and launch again:
-
-```bash
-xattr -cr /Applications/Holeberry.app
-```
+**Note on macOS Gatekeeper:** Holeberry is signed with a Developer ID and fully notarized by Apple, so macOS will not warn about an unidentified developer.
 
 ## Requirements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,11 +35,7 @@ Holeberry 是一款轻量级 macOS 菜单栏应用，让你的 Pi-hole® 触手�
 1. 从 [Releases](https://github.com/pedrovieira/Holeberry/releases) 页面下载最新的 `Holeberry-<版本号>.dmg`。
 2. 打开 DMG，将 **Holeberry** 拖入你的 `Applications` 文件夹。
 
-**关于 macOS Gatekeeper 的说明：** Holeberry 使用免费的 Apple ID 构建，未通过付费的 Apple Developer 账号进行公证（notarization）。因此 macOS 可能会将其标记为「来自身份不明的开发者」，或在首次启动时将其隔离。如果看到该提示，请移除隔离标记后重新启动：
-
-```bash
-xattr -cr /Applications/Holeberry.app
-```
+**关于 macOS Gatekeeper 的说明：** Holeberry 使用 Developer ID 签名并通过 Apple 公证（notarization），macOS 不会将其标记为「来自身份不明的开发者」。
 
 ## 系统要求
 

--- a/Sources/Holeberry/App/Updater/UpdateManager.swift
+++ b/Sources/Holeberry/App/Updater/UpdateManager.swift
@@ -81,7 +81,9 @@ final class UpdateManager: NSObject, SPUUpdaterDelegate, SPUUserDriver {
   func showExtractionReceivedProgress(_ progress: Double) {}
 
   func showReady(toInstallAndRelaunch reply: @escaping (SPUUserUpdateChoice) -> Void) {
-    reply(.dismiss)
+    // The user already chose "Update & Restart" in the update alert, so proceed
+    // with the install without asking again.
+    reply(.install)
   }
 
   func showInstallingUpdate(
@@ -118,7 +120,7 @@ final class UpdateManager: NSObject, SPUUpdaterDelegate, SPUUserDriver {
 
     alert.informativeText = info
     alert.alertStyle = .informational
-    alert.addButton(withTitle: "View on GitHub")
+    alert.addButton(withTitle: "Update & Restart")
     alert.addButton(withTitle: "Skip This Version")
     alert.addButton(withTitle: "Remind Me Later")
 
@@ -128,12 +130,9 @@ final class UpdateManager: NSObject, SPUUpdaterDelegate, SPUUserDriver {
     let response = alert.runModal()
     switch response {
     case .alertFirstButtonReturn:
-      // View on GitHub
-      let tag = newVersion.hasPrefix("v") ? newVersion : "v\(newVersion)"
-      if let url = URL(string: "https://github.com/pedrovieira/Holeberry/releases/tag/\(tag)") {
-        NSWorkspace.shared.open(url)
-      }
-      reply?(.dismiss)
+      // Update & Restart — Sparkle downloads the notarized DMG and installs it
+      // in place (see showReady(toInstallAndRelaunch:)).
+      reply?(.install)
 
     case .alertSecondButtonReturn:
       // Skip This Version — Sparkle won't notify about this version again

--- a/Sources/Holeberry/Settings/SettingsView.swift
+++ b/Sources/Holeberry/Settings/SettingsView.swift
@@ -78,7 +78,7 @@ struct SettingsView: View {
         } icon: {
           tab.image
             .resizable()
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .frame(width: 16, height: 16)
         }
       }
@@ -301,7 +301,7 @@ struct SettingsView: View {
             VStack(spacing: 5) {
               Image("Github")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 18)
               Text("GitHub")
             }
@@ -322,7 +322,7 @@ struct SettingsView: View {
             VStack(spacing: 4) {
               Image("Github")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 16, height: 16)
               Text("GitHub")
                 .font(.caption2)
@@ -382,7 +382,7 @@ struct SettingsView: View {
       VStack(spacing: 4) {
         icon
           .resizable()
-          .aspectRatio(contentMode: .fit)
+          .scaledToFit()
           .frame(width: 16, height: 16)
         Text(label)
           .font(.caption2)

--- a/project.yml
+++ b/project.yml
@@ -48,6 +48,7 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Sources/Holeberry/Support/Holeberry.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: me.pedrovieira.holeberry
         CODE_SIGN_STYLE: Automatic
+        ENABLE_HARDENED_RUNTIME: YES
         ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS: YES
         SWIFT_UPCOMING_FEATURE_EXISTENTIAL_ANY: YES
     dependencies:


### PR DESCRIPTION
## Summary

Holeberry has been distributed ad-hoc (no signing secrets configured), so macOS flagged it as an unidentified developer and users had to clear the quarantine attribute manually. With a paid Apple Developer account now in place, this PR makes the release pipeline produce **fully notarized Developer ID builds** and switches the update flow to install in place via Sparkle.

## Changes

- **project.yml** — enable `ENABLE_HARDENED_RUNTIME` (required by Apple's notarization service). `.xcodeproj` regenerated (hardened runtime + committed Developer ID identity).
- **.github/workflows/release.yml**
  - Developer ID signing with hardened runtime; `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` (Xcode 26 injects the restricted `get-task-allow` entitlement into Release builds otherwise, which the notary service rejects)
  - Re-sign Sparkle's nested code (XPC services, Updater.app, Autoupdate) inside-out with the Developer ID identity — the XCFramework ships them ad-hoc signed and the notary service rejects ad-hoc nested code — plus a team-ID audit of every Mach-O in the bundle
  - Notarization via App Store Connect API key: zip-based `notarytool submit` (bare `.app` is no longer accepted), `--wait --timeout 30m`, `stapler staple` + `validate` for **both** the app and the DMG, with automatic Apple-log output on rejection (note: `notarytool` exits 0 even on an `Invalid` verdict, so the workflow parses the status itself)
  - Fail-fast check that the p12 contains a private key (a certificate-only p12 imports fine but leaves no signing identity)
- **.github/workflows/project-drift.yml** — fork fallback identity updated to match the committed project.
- **Sources/Holeberry/App/Updater/UpdateManager.swift** — the update alert now offers "Update & Restart" (Sparkle downloads the notarized archive and installs in place) instead of opening the GitHub releases page; `showReady(toInstallAndRelaunch:)` replies `.install` instead of `.dismiss`, which previously cancelled every install.
- **Sources/Holeberry/Settings/SettingsView.swift** — replace `aspectRatio(contentMode:)` with `scaledToFit()` (Xcode 26's legacy-SwiftUI diagnostics make the old form a build error).
- **README.md / README.zh-CN.md / README.ja.md** — document that releases are now Developer ID-signed and notarized; remove the `xattr -cr` workaround.

## Verification

- Full end-to-end local run of the release pipeline against Apple's notary service: **app and DMG both `status: Accepted`**, tickets stapled and validated, `spctl --assess --type execute` reports `accepted source=Notarized Developer ID`.
- Release build succeeds on Xcode 26 with the new settings; SwiftLint + swift-format strict pass.
- The ad-hoc fallback path (used when no signing secrets are configured, e.g. fork runs) is preserved.

## Notes

The release workflow requires these repository secrets (not set in this PR): `HOLEBERRY_TEAM_ID`, `HOLEBERRY_CODE_SIGN_IDENTITY`, `HOLEBERRY_CERT_P12` (+ password), `APPLE_API_KEY` (+ key ID + issuer ID) — plus the existing `RELEASE_PAT` and `PRIVATE_SPARKLE_KEY`.
