### PR TITLE
feat: add Custom... duration option to the Unblock Current Tab shortcut

### DIFF
--- a/Packages/HoleberryCore/Sources/HoleberryCore/Models/UnblockCurrentTabDurationSelection.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Models/UnblockCurrentTabDurationSelection.swift
@@ -2,7 +2,8 @@ import Defaults
 import Foundation
 
 /// What the "Unblock Current Tab" global shortcut should do when it fires:
-/// unblock for one of the user's configured duration entries, or indefinitely.
+/// unblock for one of the user's configured duration entries, indefinitely,
+/// or for a duration prompted when the shortcut fires.
 ///
 /// Stored as a reference to an entry's id (not its seconds), so editing a
 /// duration in the Durations tab keeps the selection valid and its displayed
@@ -14,15 +15,18 @@ public enum UnblockCurrentTabDurationSelection: Codable, Hashable, Sendable {
   case indefinite
   /// Unblock for the configured duration entry with this id.
   case entry(UUID)
+  /// Prompt for a duration each time the shortcut fires.
+  case custom
 
   /// Resolves the selection against the live duration entries.
   ///
   /// - Returns: The entry's seconds for a finite unblock, or `nil` when the
-  ///   selection is `.indefinite` or references an entry that no longer
-  ///   exists (deleted in the Durations tab after being selected here).
+  ///   selection is `.indefinite`, is `.custom` (the duration is chosen when
+  ///   the shortcut fires), or references an entry that no longer exists
+  ///   (deleted in the Durations tab after being selected here).
   public func resolve(durations: [UnblockDurationEntry]) -> TimeInterval? {
     switch self {
-    case .indefinite:
+    case .indefinite, .custom:
       return nil
     case .entry(let id):
       return durations.first { $0.id == id }?.seconds
@@ -34,7 +38,7 @@ public enum UnblockCurrentTabDurationSelection: Codable, Hashable, Sendable {
   /// shortcut will actually use.
   public func healed(durations: [UnblockDurationEntry]) -> UnblockCurrentTabDurationSelection {
     switch self {
-    case .indefinite:
+    case .indefinite, .custom:
       return self
     case .entry(let id):
       return durations.contains { $0.id == id } ? self : .indefinite

--- a/Packages/HoleberryCore/Tests/HoleberryCoreTests/Models/UnblockCurrentTabDurationSelectionTests.swift
+++ b/Packages/HoleberryCore/Tests/HoleberryCoreTests/Models/UnblockCurrentTabDurationSelectionTests.swift
@@ -24,6 +24,18 @@ struct UnblockCurrentTabDurationSelectionTests {
     #expect(selection.resolve(durations: []) == nil)
   }
 
+  @Test func customResolvesToNilUntilPrompted() {
+    #expect(UnblockCurrentTabDurationSelection.custom.resolve(durations: []) == nil)
+    #expect(
+      UnblockCurrentTabDurationSelection.custom.resolve(durations: UnblockDurationEntry.defaultEntries) == nil)
+  }
+
+  @Test func customNeverHealsAway() {
+    #expect(UnblockCurrentTabDurationSelection.custom.healed(durations: []) == .custom)
+    #expect(
+      UnblockCurrentTabDurationSelection.custom.healed(durations: UnblockDurationEntry.defaultEntries) == .custom)
+  }
+
   @Test func resolutionIsIDBasedNotSecondsBased() {
     // A re-added "5 minutes" entry gets a fresh UUID and must not satisfy an
     // old selection referencing the deleted default entry.
@@ -57,5 +69,7 @@ struct UnblockCurrentTabDurationSelectionTests {
     #expect(Defaults[.unblockCurrentTabDuration(suite: suite)] == .entry(UnblockDurationEntry.default10sID))
     Defaults[.unblockCurrentTabDuration(suite: suite)] = .indefinite
     #expect(Defaults[.unblockCurrentTabDuration(suite: suite)] == .indefinite)
+    Defaults[.unblockCurrentTabDuration(suite: suite)] = .custom
+    #expect(Defaults[.unblockCurrentTabDuration(suite: suite)] == .custom)
   }
 }

--- a/Sources/Holeberry/Settings/UnblockCurrentTabDurationPicker.swift
+++ b/Sources/Holeberry/Settings/UnblockCurrentTabDurationPicker.swift
@@ -2,7 +2,8 @@ import HoleberryCore
 import SwiftUI
 
 /// The "Duration" sub-row of the "Unblock Current Tab" shortcut in the
-/// Shortcuts tab: a picker over the configured durations plus "Indefinite".
+/// Shortcuts tab: a picker over the configured durations plus "Indefinite"
+/// and "Custom...".
 ///
 /// Repairs a dangling `.entry` selection (its duration was deleted in the
 /// Durations tab) to `.indefinite`, so the picker always displays the value
@@ -21,6 +22,8 @@ struct UnblockCurrentTabDurationPicker: View {
         }
         Text("Indefinite")
           .tag(UnblockCurrentTabDurationSelection.indefinite)
+        Text("Custom...")
+          .tag(UnblockCurrentTabDurationSelection.custom)
       }
       .labelsHidden()
       .pickerStyle(.menu)

--- a/Sources/Holeberry/Shortcuts/ShortcutController.swift
+++ b/Sources/Holeberry/Shortcuts/ShortcutController.swift
@@ -66,7 +66,12 @@ final class ShortcutController {
         if healed != selection {
           Defaults[.unblockCurrentTabDuration(suite: self.defaultsSuite)] = healed
         }
-        await self.unblockOnAllServers(domain: domain, duration: healed.resolve(durations: durations))
+        switch healed {
+        case .entry, .indefinite:
+          await self.unblockOnAllServers(domain: domain, duration: healed.resolve(durations: durations))
+        case .custom:
+          await self.promptCustomDurationThenUnblock(domain: domain)
+        }
       }
     }
 
@@ -172,6 +177,26 @@ final class ShortcutController {
 
     guard let duration = seconds else { return }
     await setBlockingOnAll(enabled: false, duration: duration)
+  }
+
+  private func promptCustomDurationThenUnblock(domain: String) async {
+    guard !serverManager.servers.isEmpty else {
+      logger.debug("Unblock current tab shortcut fired but no servers configured — skipping")
+      return
+    }
+
+    // Show DurationPickerAlert on main thread, then get the result
+    let seconds = await MainActor.run { () -> TimeInterval? in
+      let alert = DurationPickerAlert(
+        title: "Custom Unblock Duration",
+        message: "Choose how long to unblock \"\(domain)\".",
+        confirmButton: "Unblock"
+      )
+      return alert.runDurationPicker()
+    }
+
+    guard let duration = seconds else { return }
+    await unblockOnAllServers(domain: domain, duration: duration)
   }
 
   // MARK: - Error Notification


### PR DESCRIPTION
## Problem

The **Unblock Current Tab** shortcut's duration dropdown (Settings → Shortcuts) only offered the user's configured duration entries or "Indefinite". A user who wanted to unblock the current tab for an arbitrary length of time — e.g. 2 minutes — had no way to do it with this shortcut; the custom-duration flow only existed for the separate "Custom duration..." shortcut and the menu bar.

## What changed

<img width="389" height="236" alt="image" src="https://github.com/user-attachments/assets/1632f0c1-4e07-47a5-8288-6bd23927ff76" />
</br>
  
  
- **`UnblockCurrentTabDurationSelection`** (HoleberryCore): new persisted `.custom` case. It resolves to `nil` (the duration is chosen when the shortcut fires) and never heals away, so the picker always shows what the shortcut will do.
- **`UnblockCurrentTabDurationPicker`**: "Custom..." row added as the **last** option in the dropdown (after the duration entries and "Indefinite").
- **`ShortcutController`**: the `.unblockCurrentTab` handler now switches on the selection. `.entry` / `.indefinite` behave exactly as before; `.custom` presents the existing `DurationPickerAlert` ("Custom Unblock Duration" / "Choose how long to unblock \"example.com\"." / "Unblock" — same wording as the menu bar's Custom... item) and unblocks the tab for the entered duration. Cancelling the alert is a no-op and the selection stays "Custom..." for next time.
- **Tests**: new cases for `.custom` — resolves to `nil`, never heals away, and round-trips through `Defaults`.

## Verification

| Check | Result |
| --- | --- |
| `swift test` (Packages/HoleberryCore) | 360 tests passed (incl. 2 new tests, 10/10 in the selection suite) |
| `swiftlint --strict Sources/ Packages/HoleberryCore/Sources/` | 0 violations |
| `swift-format lint --recursive --strict Sources/ Packages/HoleberryCore/Sources/` | clean |
| `xcodebuild -scheme Holeberry -configuration Debug build` | BUILD SUCCEEDED (strict lint/format pre-build scripts included) |

## Existing PRs

Searched open and closed PRs (`gh pr list --state all --search "custom duration"` and full list) — no prior PR addresses this. The custom-duration UX itself (prompt at trigger time via `DurationPickerAlert`) follows the existing "Custom duration..." shortcut and menu-bar Custom... items.