### PR TITLE
feat: add Waterfox and Helium browser support; fix Automation prompt on macOS 26

### DIFF
--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/Browser.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/Browser.swift
@@ -29,12 +29,16 @@ public enum Browser: String, CaseIterable {
   // Vivaldi
   case vivaldi = "com.vivaldi.Vivaldi"
   case vivaldiSnapshot = "com.vivaldi.Vivaldi.snapshot"
+  // Helium
+  case helium = "net.imput.helium"
   // Firefox
   case firefox = "org.mozilla.firefox"
   case firefoxDeveloperEdition = "org.mozilla.firefoxdeveloperedition"
   case firefoxNightly = "org.mozilla.nightly"
   // Zen Browser
   case zen = "app.zen-browser.zen"
+  // Waterfox
+  case waterfox = "net.waterfox.waterfox"
 
   public var bundleID: String { rawValue }
 
@@ -61,10 +65,12 @@ public enum Browser: String, CaseIterable {
     case .operaDeveloper: return "Opera Developer"
     case .vivaldi: return "Vivaldi"
     case .vivaldiSnapshot: return "Vivaldi Snapshot"
+    case .helium: return "Helium"
     case .firefox: return "Firefox"
     case .firefoxDeveloperEdition: return "Firefox Developer Edition"
     case .firefoxNightly: return "Firefox Nightly"
     case .zen: return "Zen Browser"
+    case .waterfox: return "Waterfox"
     }
   }
 }

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/BrowserActiveUrlFetchingStrategyFactory.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/BrowserActiveUrlFetchingStrategyFactory.swift
@@ -28,6 +28,8 @@ public struct BrowserActiveUrlFetchingStrategyFactory: UrlFetchingStrategyFactor
       return GeckoSessionStoreUrlFetchingStrategy(supportDirName: "Firefox", category: "firefox-sessionstore")
     case .zen:
       return GeckoSessionStoreUrlFetchingStrategy(supportDirName: "zen", category: "zen-sessionstore")
+    case .waterfox:
+      return GeckoSessionStoreUrlFetchingStrategy(supportDirName: "Waterfox", category: "waterfox-sessionstore")
 
     // Chromium-based browsers — all fall through to Chrome
     case .edge, .edgeBeta, .edgeDev, .edgeCanary,
@@ -35,6 +37,7 @@ public struct BrowserActiveUrlFetchingStrategyFactory: UrlFetchingStrategyFactor
       .arc,
       .opera, .operaNext, .operaDeveloper,
       .vivaldi, .vivaldiSnapshot,
+      .helium,
       .chrome, .chromeBeta, .chromeDev, .chromeCanary:
       return ChromiumUrlFetchingStrategy(
         appName: browser.appName,

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/GeckoSessionStoreUrlFetchingStrategy.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/GeckoSessionStoreUrlFetchingStrategy.swift
@@ -43,11 +43,11 @@ final class GeckoSessionStoreUrlFetchingStrategy: BrowserActiveUrlFetchingStrate
   // MARK: - Permission
 
   func isPermissionGranted(for browser: Browser) -> AutomationPermission {
-    .allowed  // Firefox reads session files, no Apple Events needed
+    .allowed  // Gecko-based browsers read session files, no Apple Events needed
   }
 
   func requestPermission(for browser: Browser) {
-    // No-op: Firefox doesn't use Apple Events
+    // No-op: Gecko-based browsers doesn't use Apple Events
   }
 
   // MARK: - profiles.ini parsing

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/GeckoSessionStoreUrlFetchingStrategy.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/GeckoSessionStoreUrlFetchingStrategy.swift
@@ -47,7 +47,7 @@ final class GeckoSessionStoreUrlFetchingStrategy: BrowserActiveUrlFetchingStrate
   }
 
   func requestPermission(for browser: Browser) {
-    // No-op: Gecko-based browsers doesn't use Apple Events
+    // No-op: Gecko-based browsers don't use Apple Events
   }
 
   // MARK: - profiles.ini parsing

--- a/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/BrowserDetector/BrowserActiveUrlFetchingStrategyFactoryTests.swift
+++ b/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/BrowserDetector/BrowserActiveUrlFetchingStrategyFactoryTests.swift
@@ -38,6 +38,18 @@ struct BrowserActiveUrlFetchingStrategyFactoryTests {
     #expect(strategy is GeckoSessionStoreUrlFetchingStrategy)
   }
 
+  @Test("Waterfox uses GeckoSessionStoreUrlFetchingStrategy")
+  func waterfoxStrategy() {
+    let strategy = factory.strategy(for: .waterfox)
+    #expect(strategy is GeckoSessionStoreUrlFetchingStrategy)
+  }
+
+  @Test("Helium uses ChromiumUrlFetchingStrategy")
+  func heliumStrategy() {
+    let strategy = factory.strategy(for: .helium)
+    #expect(strategy is ChromiumUrlFetchingStrategy)
+  }
+
   @Test("Arc uses ChromiumUrlFetchingStrategy")
   func arcStrategy() {
     let strategy = factory.strategy(for: .arc)

--- a/README.ja.md
+++ b/README.ja.md
@@ -76,7 +76,7 @@ xattr -cr /Applications/Holeberry.app
 
 ### 今見ているブラウザタブをブロック解除
 
-Holeberry は **WebKit（Safari、Orion）、Chrome/Chromium、Gecko（Firefox & Zen）ブラウザー**の現在のタブを検出し、そのドメインをワンクリックでブロック解除します——Pi-hole のブロッキングでページが読み込めないときにぴったりです。[対応ブラウザの完全なリスト](docs/SUPPORTED-BROWSERS.md)を参照してください。
+Holeberry は **WebKit（Safari、Orion）、Chrome/Chromium、Gecko（Firefox、Zen など）**の現在のタブを検出し、そのドメインをワンクリックでブロック解除します——Pi-hole のブロッキングでページが読み込めないときにぴったりです。[対応ブラウザの完全なリスト](docs/SUPPORTED-BROWSERS.md)を参照してください。
 
 単一ドメインのブロック解除はグローバルな無効化より優れています：ページは読み込まれ、ネットワークの他の部分は保護されたままです。（スマート TV は同意しないでしょう——外の世界に大量のトラフィックを送るので、グローバルなブロック解除を喜ぶに違いありません。話を聞いてはいけません。）ドメインを許可リストに追加することもできます。
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A quick way to disable blocking **globally** on all your Pi-hole® instances for
 
 ### Unblock the browser tab you're on
 
-Holeberry detects the current tab in **WebKit (Safari, Orion), Chrome/Chromium, Gecko (Firefox & Zen) Browser** and unblocks that exact domain with one click — perfect when a page fails to load because Pi-hole blocked it. See the [full list of supported browsers](docs/SUPPORTED-BROWSERS.md).
+Holeberry detects the current tab in **WebKit (Safari, Orion), Chrome/Chromium, Gecko (Firefox, Zen, etc...)** and unblocks that exact domain with one click — perfect when a page fails to load because Pi-hole blocked it. See the [full list of supported browsers](docs/SUPPORTED-BROWSERS.md).
 
 Unblocking a single domain beats a global disable: the page loads while the rest of your network stays protected. (Your smart TV would disagree — it sends so much traffic out into the world it would love a global unblock. Don't listen to it.) You can also add the domain to your allowlist.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ xattr -cr /Applications/Holeberry.app
 
 ### 解除当前浏览器标签页的屏蔽
 
-Holeberry 能检测 **WebKit（Safari、Orion）、Chrome/Chromium、Gecko（Firefox 与 Zen）浏览器**中的当前标签页，一键解除该域名的屏蔽——当页面因 Pi-hole 屏蔽而无法加载时尤其好用。查看[支持的浏览器完整列表](docs/SUPPORTED-BROWSERS.md)。
+Holeberry 能检测 **WebKit（Safari、Orion）、Chrome/Chromium、Gecko（Firefox、Zen 等）**中的当前标签页，一键解除该域名的屏蔽——当页面因 Pi-hole 屏蔽而无法加载时尤其好用。查看[支持的浏览器完整列表](docs/SUPPORTED-BROWSERS.md)。
 
 解除单个域名的屏蔽胜过全局禁用：页面能正常加载，网络的其他部分仍然受到保护。（你的智能电视可不会同意——它向外界发送的流量实在太多，恨不得来个全局解除。别听它的。）你也可以顺手把该域名加入白名单。
 

--- a/Sources/Holeberry/Settings/BrowserTabSettingsView.swift
+++ b/Sources/Holeberry/Settings/BrowserTabSettingsView.swift
@@ -67,11 +67,11 @@ private struct BrowserTabInfoPopover: View {
       VStack(alignment: .leading, spacing: 2) {
         Text("• WebKit (Safari, Orion)")
         Text("• Chromium (Chrome, etc.)")
-        Text("• Gecko (Firefox)")
+        Text("• Gecko (Firefox, Zen, etc.)")
       }
       .font(.system(size: 11))
 
-      Text("Support for Firefox and Zen Browser is experimental and not fully tested.")
+      Text("Support for Gecko-based browsers is experimental and not fully tested.")
         .font(.system(size: 11))
         .foregroundColor(.secondary)
         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/Holeberry/Support/Holeberry.entitlements
+++ b/Sources/Holeberry/Support/Holeberry.entitlements
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.personal-information.keychain</key>
     <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
     <key>com.apple.security.temporary-exception.apple-events</key>
     <array>
         <string>com.apple.Safari</string>
@@ -29,12 +31,14 @@
         <string>com.operasoftware.OperaDeveloper</string>
         <string>com.vivaldi.Vivaldi</string>
         <string>com.vivaldi.Vivaldi.snapshot</string>
+        <string>net.imput.helium</string>
     </array>
 
     <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
     <array>
         <string>/Library/Application Support/Firefox/</string>
         <string>/Library/Application Support/zen/</string>
+        <string>/Library/Application Support/Waterfox/</string>
     </array>
 
     <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>

--- a/docs/SUPPORTED-BROWSERS.md
+++ b/docs/SUPPORTED-BROWSERS.md
@@ -32,8 +32,9 @@ Holeberry can read the domain from your current browser tab and unblock it. This
 | Opera Developer | `com.operasoftware.OperaDeveloper` |
 | Vivaldi | `com.vivaldi.Vivaldi` |
 | Vivaldi Snapshot | `com.vivaldi.Vivaldi.snapshot` |
+| Helium | `net.imput.helium` |
 
-## Gecko (Firefox)
+## Gecko (Firefox family)
 
 | Browser | Bundle ID |
 | --- | --- |
@@ -41,11 +42,12 @@ Holeberry can read the domain from your current browser tab and unblock it. This
 | Firefox Developer Edition | `org.mozilla.firefoxdeveloperedition` |
 | Firefox Nightly | `org.mozilla.nightly` |
 | Zen Browser | `app.zen-browser.zen` |
+| Waterfox | `net.waterfox.waterfox` |
 
 ## How tab detection works
 
 - **WebKit (Safari, Orion) and Chromium-based browsers** — Holeberry uses AppleScript to ask the browser for its active tab URL. macOS asks for Automation permission on first use (System Settings → Privacy & Security → Automation); without it, tab detection is unavailable for that browser.
-- **Firefox and Zen Browser** — Holeberry reads the browser's `sessionstore.jsonlz4` file directly, so no Automation permission is needed. This method is **experimental and not fully tested** and may break with future browser versions.
+- **Firefox, Zen Browser, and Waterfox** — Holeberry reads the browser's `sessionstore.jsonlz4` file directly, so no Automation permission is needed. This method is **experimental and not fully tested** and may break with future browser versions.
 
   > **Note:** It may take a few seconds for the current tab's URL to become available — these browsers write their session store to disk in their own time.
 


### PR DESCRIPTION
Related: https://github.com/pedrovieira/Holeberry/issues/15

## Summary

Adds support for two new browsers to browser-tab detection, plus a macOS 26 permission fix:

- **Waterfox** (`net.waterfox.waterfox`) — Gecko family. Uses the existing `GeckoSessionStoreUrlFetchingStrategy` unchanged (reads `profiles.ini` + `sessionstore.jsonlz4`/`recovery.jsonlz4` under `~/Library/Application Support/Waterfox/`), so no AppleScript/Automation permission is needed.
- **Helium** (`net.imput.helium`) — Chromium-based. Uses the existing `ChromiumUrlFetchingStrategy` (`get URL of active tab of front window`). Bundle ID, app name, and the AppleScript dictionary (`scripting.sdef`: `active tab` + `URL` properties) were verified against the shipped `helium_0.15.7.1` DMG.
- **macOS 26 Automation fix** — adds `com.apple.security.automation.apple-events` to the entitlements. On macOS 26, hardened-runtime policy requires this entitlement to show the Automation permission prompt; without it, tccd logs `Policy disallows prompt ... access denied` and the click silently does nothing. This affects **all** browsers on macOS 26 with a not-yet-granted Automation permission (existing grants keep working), not just Helium.

## What changed

- `Browser` enum: new `helium` / `waterfox` cases + `appName`
- `BrowserActiveUrlFetchingStrategyFactory`: routings for both browsers (switch stays exhaustive)
- `Holeberry.entitlements`: `net.imput.helium` in the Apple Events exception list, `/Library/Application Support/Waterfox/` read-only exception, and the new `com.apple.security.automation.apple-events` key
- Tests: per-browser factory tests; `Browser.allCases` sweeps cover the new cases
- Docs/UI: `docs/SUPPORTED-BROWSERS.md`, README (en/ja/zh-CN — Gecko blurb no longer enumerates the whole family), Settings popover; Gecko strategy comments generalized