### PR TITLE
fix: open supported browsers list from the app's version tag

### DIFF
--- a/Sources/Holeberry/Settings/BrowserTabSettingsView.swift
+++ b/Sources/Holeberry/Settings/BrowserTabSettingsView.swift
@@ -54,6 +54,16 @@ private struct BrowserTabInfoPopover: View {
   /// Called when the user opens the full browser list so the popover can close.
   let onOpenFullList: () -> Void
 
+  /// URL of the full supported-browsers list on the tag matching this app's
+  /// bundle version (e.g. `v1.0.2`), so users see a list matching the version
+  /// they're running. Falls back to `main` if the version is unavailable.
+  private var supportedBrowsersURL: URL? {
+    let ref = Bundle.main.releaseVersionNumber.map { "v\($0)" } ?? "main"
+    return URL(
+      string: "https://github.com/pedrovieira/Holeberry/blob/\(ref)/docs/SUPPORTED-BROWSERS.md"
+    )
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       Text("Browser Tab Unblocking")
@@ -78,7 +88,7 @@ private struct BrowserTabInfoPopover: View {
 
       Button {
         onOpenFullList()
-        if let url = URL(string: "https://github.com/pedrovieira/Holeberry/blob/main/docs/SUPPORTED-BROWSERS.md") {
+        if let url = supportedBrowsersURL {
           NSWorkspace.shared.open(url)
         }
       } label: {


### PR DESCRIPTION
## Problem

The info popover next to the **Enable browser tab unblocking** toggle (Settings → General) links to the full list of supported browsers at:

`https://github.com/pedrovieira/Holeberry/blob/main/docs/SUPPORTED-BROWSERS.md`

Since it points at the `main` branch, a user on an older release sees the *current* supported-browsers list, which can differ from what their installed version actually supports.

## Change

`BrowserTabInfoPopover` now builds the link from the tag matching the app's bundle version:

- Uses `Bundle.main.releaseVersionNumber` (`CFBundleShortVersionString`, e.g. `1.0.2`) → `https://github.com/pedrovieira/Holeberry/blob/v1.0.2/docs/SUPPORTED-BROWSERS.md`
- Falls back to `main` if the bundle version is unavailable (e.g. non-standard dev builds)

Tags in this repo already follow the `vX.Y.Z` convention (`v1.0.0`, `v1.0.1`, `v1.0.2`) and match `CFBundleShortVersionString`, so no repo changes are needed.

## Verification

- `swiftlint --strict` on the changed file — clean
- `xcrun swift-format lint --strict` on the changed file — clean
- `xcodebuild -project Holeberry.xcodeproj -scheme Holeberry -configuration Debug build` — **BUILD SUCCEEDED** (pre-build SwiftLint / swift-format script phases ran in strict mode)