### PR TITLE
fix: sanitize Gecko profile paths from profiles.ini against path traversal

### DIFF
--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/GeckoSessionStoreUrlFetchingStrategy.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/BrowserDetector/GeckoSessionStoreUrlFetchingStrategy.swift
@@ -125,11 +125,41 @@ final class GeckoSessionStoreUrlFetchingStrategy: BrowserActiveUrlFetchingStrate
     return nil
   }
 
-  static func resolvePath(_ path: String, isRelative: Bool, supportDir: URL) -> URL {
-    if isRelative {
-      return supportDir.appendingPathComponent(path)
+  /// Resolves a profile path from `profiles.ini` content, sanitizing it against path traversal.
+  ///
+  /// Gecko browsers support both relative (`IsRelative=1`) and absolute (`IsRelative=0`)
+  /// profile paths, so both are kept. `profiles.ini` is user-writable, so `.` and `..`
+  /// components are resolved lexically here instead of being passed to Foundation path
+  /// APIs: a relative path that would escape `supportDir` is rejected, while absolute
+  /// paths are normalized against the filesystem root. The URL is built only from the
+  /// resolved, in-bounds components.
+  static func resolvePath(_ path: String, isRelative: Bool, supportDir: URL) -> URL? {
+    let rawComponents = path.split(separator: "/").map(String.init)
+    guard !rawComponents.isEmpty else { return nil }
+
+    let isAbsolute = path.hasPrefix("/")
+    guard isRelative || isAbsolute else { return nil }
+
+    let base: URL = isAbsolute ? URL(fileURLWithPath: "/") : supportDir.standardizedFileURL
+    var components: [String] = []
+    for component in rawComponents {
+      if component == "." {
+        continue
+      }
+      if component == ".." {
+        if !components.isEmpty {
+          components.removeLast()
+          continue
+        }
+        // Nothing left to pop: on relative paths this escapes `supportDir`; on
+        // absolute paths `..` at the root is a no-op.
+        guard isAbsolute else { return nil }
+        continue
+      }
+      components.append(component)
     }
-    return URL(fileURLWithPath: path)
+
+    return components.reduce(base) { $0.appendingPathComponent($1) }
   }
 
   // MARK: - mozLZ4 decompression

--- a/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/BrowserDetector/GeckoSessionStoreTests.swift
+++ b/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/BrowserDetector/GeckoSessionStoreTests.swift
@@ -48,6 +48,17 @@ struct GeckoSessionStoreTests {
     #expect(path?.path == "/Users/test/Library/Application Support/Firefox/test-profile")
   }
 
+  @Test("rejects Install default with traversal path")
+  func installSectionRejectsTraversal() {
+    let ini = """
+      [Install404C0A7C0A7C404C]
+      Default=../../../../etc
+      Locked=1
+      """
+    let path = GeckoSessionStoreUrlFetchingStrategy.resolveProfileFromInstallSection(in: ini, supportDir: supportDir)
+    #expect(path == nil)
+  }
+
   // MARK: - profiles.ini: Profile section
 
   @Test("resolves Profile section with Default=1")
@@ -101,6 +112,19 @@ struct GeckoSessionStoreTests {
     #expect(path?.path == "/Users/custom/Library/Firefox/Profiles/custom")
   }
 
+  @Test("rejects default profile with traversal path")
+  func profileSectionRejectsTraversal() {
+    let ini = """
+      [Profile0]
+      Name=default
+      Path=../../etc
+      Default=1
+      IsRelative=1
+      """
+    let path = GeckoSessionStoreUrlFetchingStrategy.resolveProfileFromProfileSection(in: ini, supportDir: supportDir)
+    #expect(path == nil)
+  }
+
   @Test("returns nil when no default profile")
   func profileSectionNoDefault() {
     let ini = """
@@ -126,14 +150,63 @@ struct GeckoSessionStoreTests {
   func resolvePathRelative() {
     let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
       "Profiles/test", isRelative: true, supportDir: supportDir)
-    #expect(url.path == "/Users/test/Library/Application Support/Firefox/Profiles/test")
+    #expect(url?.path == "/Users/test/Library/Application Support/Firefox/Profiles/test")
   }
 
   @Test("resolvePath absolute returns as-is")
   func resolvePathAbsolute() {
     let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
       "/custom/path", isRelative: false, supportDir: supportDir)
-    #expect(url.path == "/custom/path")
+    #expect(url?.path == "/custom/path")
+  }
+
+  @Test("resolvePath rejects path traversal in relative paths")
+  func resolvePathRejectsTraversal() {
+    let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
+      "../../../etc", isRelative: true, supportDir: supportDir)
+    #expect(url == nil)
+  }
+
+  @Test("resolvePath allows redundant dot components")
+  func resolvePathAllowsDotComponents() {
+    let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
+      "./Profiles/test", isRelative: true, supportDir: supportDir)
+    #expect(url?.path == "/Users/test/Library/Application Support/Firefox/Profiles/test")
+  }
+
+  @Test("resolvePath allows parent components that stay in bounds")
+  func resolvePathAllowsInBoundsParentComponents() {
+    let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
+      "Profiles/../custom", isRelative: true, supportDir: supportDir)
+    #expect(url?.path == "/Users/test/Library/Application Support/Firefox/custom")
+  }
+
+  @Test("resolvePath rejects parent components escaping through a subpath")
+  func resolvePathRejectsEscapeThroughParentComponents() {
+    let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
+      "Profiles/../../etc", isRelative: true, supportDir: supportDir)
+    #expect(url == nil)
+  }
+
+  @Test("resolvePath normalizes parent components in absolute paths")
+  func resolvePathNormalizesAbsoluteParentComponents() {
+    let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
+      "/Users/test/../../etc", isRelative: false, supportDir: supportDir)
+    #expect(url?.path == "/etc")
+  }
+
+  @Test("resolvePath rejects relative value when IsRelative=0")
+  func resolvePathRejectsNonAbsoluteWhenAbsoluteRequired() {
+    let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
+      "Profiles/test", isRelative: false, supportDir: supportDir)
+    #expect(url == nil)
+  }
+
+  @Test("resolvePath rejects empty path")
+  func resolvePathRejectsEmpty() {
+    let url = GeckoSessionStoreUrlFetchingStrategy.resolvePath(
+      "", isRelative: true, supportDir: supportDir)
+    #expect(url == nil)
   }
 
   // MARK: - mozLZ4 / extractURL


### PR DESCRIPTION
## Problem

CodeQL (GitHub Advanced Security, default setup) reports **3 open `swift/path-injection` alerts** on `main` ("Uncontrolled data used in path expression", severity: error), all in `GeckoSessionStoreUrlFetchingStrategy.swift`:

- `Data(contentsOf: sessionStoreURL)` — lines 24 and 35 (`sessionstore.jsonlz4`)
- `Data(contentsOf: recoveryURL)` — line 29 (`sessionstore-backups/recovery.jsonlz4`)

The profile directory is resolved from `~/Library/Application Support/<browser>/profiles.ini`, a user-writable file, and its `Path`/`Default` values were passed straight into `supportDir.appendingPathComponent(path)` / `URL(fileURLWithPath: path)` with no validation. A relative value like `Path=../../../…` escapes the Application Support directory (CWE-22 path traversal), and absolute values (`IsRelative=0`) could point anywhere on disk.

## Change

`resolvePath` now sanitizes the value before any Foundation path API is reached:

- `.`/`..` components are resolved lexically by the app itself — no raw untrusted string ever flows into `appendingPathComponent` / `fileURLWithPath`.
- Relative paths (`IsRelative=1`) that would escape `~/Library/Application Support/<browser>` are rejected (returns `nil`, dropping into the existing graceful "Could not get tab URL" handling).
- Absolute paths (`IsRelative=0`) — a real Firefox feature for profiles stored elsewhere, e.g. another volume — are kept and normalized against the filesystem root.
- In-bounds `.`/`..` values keep working (e.g. hand-edited `Profiles/../custom`), so legitimate profile setups aren't broken; verified against the actual `profiles.ini` files Firefox, Waterfox, and zen generate (they only ever write canonical relative paths).

`resolvePath` now returns `URL?`; both callers already returned `URL?`, so no other source changes were needed.

## Tests

`GeckoSessionStoreTests` updated/added for the new boundary:

- Escapes rejected: `../../../etc`, `Profiles/../../etc`, plus end-to-end through both parsers (`[Install*]` `Default=../../../../etc` and `[Profile*]` `Path=../../etc`).
- In-bounds accepted: `./Profiles/test`, `Profiles/../custom`.
- Absolute normalization: `/Users/test/../../etc` → `/etc`.
- `IsRelative=0` without a leading `/` → `nil`; empty path → `nil`.

Verification: `swift test` — 383 tests passed (46 suites); `swiftlint --strict` and `swift-format lint --strict` clean on both changed files.

CodeQL (default setup) will re-run on this PR — expected outcome is no new `swift/path-injection` alerts on the PR head; the 3 alerts on `main` auto-close once this merges and `main` is re-scanned.
