### PR TITLE
refactor: decode v5/v6 API responses with Decodable types

### DIFF
--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeV5Service.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeV5Service.swift
@@ -102,12 +102,17 @@ public final class PiholeV5Service: PiholeServiceCommentAdding {
       throw PiholeError.server(httpResponse.statusCode, String(data: data, encoding: .utf8))
     }
 
-    // v5 returns numbers as strings in JSON with snake_case keys
-    guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let queriesTotalStr = json["queries_total"] as? String,
-      let adsBlockedStr = json["ads_blocked_today"] as? String,
-      let totalQueries = Int(queriesTotalStr),
-      let totalBlocked = Int(adsBlockedStr)
+    // v5 serves the FTL stats as float values with snake_case keys
+    let response: V5SummaryResponse
+    do {
+      response = try Self.decoder.decode(V5SummaryResponse.self, from: data)
+    } catch {
+      let body = String(data: data, encoding: .utf8) ?? ""
+      throw PiholeError.decoding("Unexpected summary format: \(body)")
+    }
+
+    guard let totalQueries = Int(exactly: response.dnsQueriesToday),
+      let totalBlocked = Int(exactly: response.adsBlockedToday)
     else {
       let body = String(data: data, encoding: .utf8) ?? ""
       throw PiholeError.decoding("Unexpected summary format: \(body)")
@@ -155,9 +160,10 @@ public final class PiholeV5Service: PiholeServiceCommentAdding {
       throw PiholeError.server(httpResponse.statusCode, String(data: data, encoding: .utf8))
     }
 
-    guard let rows = try JSONSerialization.jsonObject(with: data) as? [[Any]] else {
+    guard let response = try? Self.decoder.decode(V5RecentQueriesResponse.self, from: data) else {
       return []
     }
+    let rows = response.data
 
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
@@ -167,11 +173,11 @@ public final class PiholeV5Service: PiholeServiceCommentAdding {
 
     let blocked = rows.compactMap { row -> BlockedDomain? in
       guard row.count >= 5 else { return nil }
-      let status = "\(row[4])"
+      let status = row[4].stringValue
       guard V5QueryStatus.blocked.contains(status) else { return nil }
-      let domain = "\(row[2])"
-      let client = "\(row[3])"
-      let timestampStr = "\(row[0])"
+      let domain = row[2].stringValue
+      let client = row[3].stringValue
+      let timestampStr = row[0].stringValue
       let timestamp = dateFormatter.date(from: timestampStr) ?? Date()
       // Client-side time range filter as fallback for FTL < v5.2
       let timestampSecs = timestamp.timeIntervalSince1970
@@ -271,5 +277,54 @@ public final class PiholeV5Service: PiholeServiceCommentAdding {
       throw PiholeError.unknown("Invalid response for \(path)")
     }
     return (data, httpResponse)
+  }
+}
+
+/// `/admin/api.php?summaryRaw` response. v5 serves the FTL stats with
+/// float values and snake_case keys.
+private struct V5SummaryResponse: Decodable {
+  let dnsQueriesToday: Double
+  let adsBlockedToday: Double
+
+  enum CodingKeys: String, CodingKey {
+    case dnsQueriesToday = "dns_queries_today"
+    case adsBlockedToday = "ads_blocked_today"
+  }
+}
+
+/// `/admin/api.php?getAllQueries` response. The web layer wraps the rows
+/// (heterogeneous arrays of strings/numbers) in a `data` object.
+private struct V5RecentQueriesResponse: Decodable {
+  let data: [[V5QueryCell]]
+}
+
+/// A single cell of v5's `getAllQueries` rows, which mix strings and numbers.
+private enum V5QueryCell: Decodable {
+  case string(String)
+  case number(Double)
+  case bool(Bool)
+  case null
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let value = try? container.decode(String.self) {
+      self = .string(value)
+    } else if let value = try? container.decode(Double.self) {
+      self = .number(value)
+    } else if let value = try? container.decode(Bool.self) {
+      self = .bool(value)
+    } else {
+      self = .null
+    }
+  }
+
+  /// String form, mirroring `"\(cell)"` on the serialized value.
+  var stringValue: String {
+    switch self {
+    case .string(let value): return value
+    case .number(let value): return Double(Int(value)) == value ? String(Int(value)) : String(value)
+    case .bool(let value): return value ? "true" : "false"
+    case .null: return ""
+    }
   }
 }

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeV6Service.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/PiholeV6Service.swift
@@ -163,19 +163,18 @@ public final class PiholeV6Service: PiholeServiceCommentAdding {
       throw PiholeError.server(httpResponse.statusCode, String(data: data, encoding: .utf8))
     }
 
-    guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let queries = json["queries"] as? [String: Any],
-      let totalQueries = queries["total"] as? Int,
-      let totalBlocked = queries["blocked"] as? Int
-    else {
+    let response: SummaryResponse
+    do {
+      response = try Self.decoder.decode(SummaryResponse.self, from: data)
+    } catch {
       let body = String(data: data, encoding: .utf8) ?? ""
       logger.error("Query summary decode failed. Body: \(body, privacy: .public)")
-      throw PiholeError.decoding("Unexpected summary format")
+      throw PiholeError.decoding("Unexpected summary format: \(error.localizedDescription)")
     }
 
     return QuerySummary(
-      totalQueries: totalQueries,
-      totalBlocked: totalBlocked
+      totalQueries: response.queries.total,
+      totalBlocked: response.queries.blocked
     )
   }
 
@@ -306,4 +305,14 @@ public struct DomainsResponse: Decodable {
 private struct AddDomainBody: Encodable {
   let domain: String
   let comment: String?
+}
+
+/// `/api/stats/summary` response.
+private struct SummaryResponse: Decodable {
+  let queries: SummaryQueries
+}
+
+private struct SummaryQueries: Decodable {
+  let total: Int
+  let blocked: Int
 }

--- a/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/Pihole/PiholeV5ServiceTests.swift
+++ b/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/Pihole/PiholeV5ServiceTests.swift
@@ -141,7 +141,9 @@ final class PiholeV5ServiceTests {
       { request in
         #expect(request.url?.absoluteString.contains("summaryRaw") == true)
         let response = try #require(v5Response())
-        let data = Data(#"{"queries_total":"1500","ads_blocked_today":"75"}"#.utf8)
+        let data = Data(
+          #"{"dns_queries_today":1500.0,"ads_blocked_today":75.0,"gravity_last_updated":{"file_exists":true,"absolute":1726223567,"relative":{"days":2,"hours":3,"minutes":4}}}"#
+            .utf8)
         return (data, response)
       }
     ]
@@ -188,9 +190,9 @@ final class PiholeV5ServiceTests {
         let ts2 = dateFormatter.string(from: Date(timeIntervalSince1970: timestamp2))
         let ts3 = dateFormatter.string(from: Date(timeIntervalSince1970: timestamp3))
         let json =
-          "[[\"\(ts1)\",\"A\",\"blocked.com\",\"192.168.1.5\"," + "\"1\",\"Blocked\",\"0\"],"
+          "{\"data\":[[\"\(ts1)\",\"A\",\"blocked.com\",\"192.168.1.5\"," + "\"1\",\"Blocked\",\"0\"],"
           + "[\"\(ts2)\",\"A\",\"allowed.com\",\"192.168.1.5\"," + "\"2\",\"OK\",\"0\"],"
-          + "[\"\(ts3)\",\"A\",\"tracker.net\",\"192.168.1.10\"," + "\"1\",\"Blocked\",\"0\"]]"
+          + "[\"\(ts3)\",\"A\",\"tracker.net\",\"192.168.1.10\"," + "\"1\",\"Blocked\",\"0\"]]}"
         return (Data(json.utf8), response)
       }
     ]
@@ -363,7 +365,7 @@ final class PiholeV5ServiceTests {
       { request in
         #expect(request.url?.absoluteString.contains("client=192.168.1.50") == true)
         let response = try #require(v5Response())
-        return (Data("[]".utf8), response)
+        return (Data(#"{"data":[]}"#.utf8), response)
       }
     ]
     let blocked = try await makeService().getRecentBlocked(


### PR DESCRIPTION
## Summary

Replaces the `JSONSerialization` dictionary/array digging in `PiholeV5Service` and `PiholeV6Service` with typed `Decodable` response structs, matching the existing `DomainsResponse` style. Along the way it corrects two v5 payload shapes to match the real Pi-hole v5 API:

- `summaryRaw` returns the FTL stats as numbers (`dns_queries_today`, `ads_blocked_today`) — not string-encoded integers — so the old `as? String` + `Int(...)` casts failed on actual v5 responses.
- `getAllQueries` wraps its rows in a `data` envelope (`{"data": [[...]]}`), so the previous `as? [[Any]]` cast never matched; the fixtures now mirror the real v5 responses.

## Changes

- **`PiholeV5Service`** — adds `V5SummaryResponse`, `V5RecentQueriesResponse`, and a `V5QueryCell` enum handling the heterogeneous string/number/bool/null cells in `getAllQueries` rows. Summary values are converted with `Int(exactly:)`; decode failures still surface as `PiholeError.decoding`.
- **`PiholeV6Service`** — adds `SummaryResponse`/`SummaryQueries` for `/api/stats/summary`; keeps the existing error logging.
- **Tests** — `PiholeV5ServiceTests` fixtures updated to the real shapes (float stats, `data` envelope, empty-list envelope).

## Testing

- `cd Packages/HoleberryCore && swift test` — 374 tests pass
- `swiftlint --strict`, `swift-format lint --strict` on the package — clean
