### PR TITLE
feat: route temp-unblock failures to notifications

### DIFF
--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/ServerStatusPoller.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/ServerStatusPoller.swift
@@ -43,7 +43,7 @@ public final class ServerStatusPoller: ObservableObject {
   /// Fired when a poll observes blocking flip `.disabled` → `.enabled` without
   /// a manual action (manual toggles reflect locally and never trigger this).
   /// Fires once, when the last disabled server re-enables.
-  public var onBlockingAutoReenabled: ((Set<UUID>) -> Void)?
+  public var onBlockingRestoredAutomatically: ((Set<UUID>) -> Void)?
 
   public init(
     manager: any PiholeServerManaging,
@@ -236,7 +236,7 @@ public final class ServerStatusPoller: ObservableObject {
   }
 
   /// Re-checks blocking status on countdown end; skips while a poll is in
-  /// flight to avoid double-firing `onBlockingAutoReenabled`. The server's own
+  /// flight to avoid double-firing `onBlockingRestoredAutomatically`. The server's own
   /// timer can outlive the local countdown by a few seconds (timer resets,
   /// tick latency), so re-check briefly until it actually re-enables.
   private func refreshBlockingStatusesIfIdle() async {
@@ -260,7 +260,7 @@ public final class ServerStatusPoller: ObservableObject {
     }
   }
 
-  /// Fetches blocking status for all servers, firing `onBlockingAutoReenabled`
+  /// Fetches blocking status for all servers, firing `onBlockingRestoredAutomatically`
   /// on a poll-observed disabled→enabled transition.
   private func fetchBlockingStatuses() async {
     let generation = blockingChangeGeneration
@@ -335,7 +335,7 @@ public final class ServerStatusPoller: ObservableObject {
     timerManager.start(duration: remaining)
   }
 
-  /// Fires `onBlockingAutoReenabled` once the last disabled server re-enables
+  /// Fires `onBlockingRestoredAutomatically` once the last disabled server re-enables
   /// via poll. Manual re-enables never reach this path.
   private func notifyIfAutoReenabled(previousDisabledIDs: Set<UUID>) {
     guard !previousDisabledIDs.isEmpty else { return }
@@ -345,7 +345,7 @@ public final class ServerStatusPoller: ObservableObject {
       return false
     }
     if !autoReenabled.isEmpty, !anyStillDisabled {
-      onBlockingAutoReenabled?(autoReenabled)
+      onBlockingRestoredAutomatically?(autoReenabled)
       // The unblock has ended — drop any re-armed countdown so the pill
       // doesn't outlive the transition.
       timerManager.cancel()

--- a/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/ServerStatusPollerTests.swift
+++ b/Packages/HoleberryCore/Tests/HoleberryCoreTests/Services/ServerStatusPollerTests.swift
@@ -545,14 +545,14 @@ struct ServerStatusPollerTests {
 
   // MARK: - Auto Re-enable Detection
 
-  @Test("poll-observed disabled→enabled fires onBlockingAutoReenabled")
+  @Test("poll-observed disabled→enabled fires onBlockingRestoredAutomatically")
   func pollObservedReenableFiresCallback() async {
     let id = UUID()
     mockManager.servers = [ServerConfig(id: id, url: "http://a.local", version: .v6)]
     mockManager.getBlockingStatusStub = [id: .success(.disabled(remainingSeconds: 300))]
     let poller = makePoller()
     var firedIDs: Set<UUID>?
-    poller.onBlockingAutoReenabled = { firedIDs = $0 }
+    poller.onBlockingRestoredAutomatically = { firedIDs = $0 }
     poller.startPolling()
 
     await scheduler.fireTick()
@@ -572,7 +572,7 @@ struct ServerStatusPollerTests {
     mockManager.getBlockingStatusStub = [id: .success(.disabled(remainingSeconds: 300))]
     let poller = makePoller()
     var fired = false
-    poller.onBlockingAutoReenabled = { _ in fired = true }
+    poller.onBlockingRestoredAutomatically = { _ in fired = true }
     poller.startPolling()
 
     // Unblock via the funnel, then the user re-enables manually...
@@ -603,7 +603,7 @@ struct ServerStatusPollerTests {
     ]
     let poller = makePoller()
     var firedIDs: Set<UUID>?
-    poller.onBlockingAutoReenabled = { firedIDs = $0 }
+    poller.onBlockingRestoredAutomatically = { firedIDs = $0 }
     poller.startPolling()
 
     await scheduler.fireTick()
@@ -628,7 +628,7 @@ struct ServerStatusPollerTests {
     mockManager.getBlockingStatusStub = [id: .success(.disabled(remainingSeconds: 300))]
     let poller = makePoller()
     var fired = false
-    poller.onBlockingAutoReenabled = { _ in fired = true }
+    poller.onBlockingRestoredAutomatically = { _ in fired = true }
 
     await poller.applyBlockingChange(enabled: false, duration: 300)
 
@@ -658,7 +658,7 @@ struct ServerStatusPollerTests {
     }
     let poller = makePoller()
     var fired = false
-    poller.onBlockingAutoReenabled = { _ in fired = true }
+    poller.onBlockingRestoredAutomatically = { _ in fired = true }
     poller.startPolling()
 
     // Poll #1: snapshots .disabled, then the status fetch is held open.
@@ -810,7 +810,7 @@ struct ServerStatusPollerTests {
     )
   }
 
-  @Test("timer expiry triggers a status-only refresh and fires onBlockingAutoReenabled")
+  @Test("timer expiry triggers a status-only refresh and fires onBlockingRestoredAutomatically")
   func timerExpiryTriggersStatusOnlyRefresh() async {
     let id = UUID()
     mockManager.servers = [ServerConfig(id: id, url: "http://a.local", version: .v6)]
@@ -819,7 +819,7 @@ struct ServerStatusPollerTests {
     let timer = TimerManager()
     let poller = makePollerWithTimer(timer)
     var firedIDs: Set<UUID>?
-    poller.onBlockingAutoReenabled = { firedIDs = $0 }
+    poller.onBlockingRestoredAutomatically = { firedIDs = $0 }
 
     // Time-boxed disable with an already-expired duration; the next tick must
     // re-check status immediately.
@@ -868,7 +868,7 @@ struct ServerStatusPollerTests {
     let timer = TimerManager()
     let poller = makePollerWithTimer(timer)
     var firedIDs: Set<UUID>?
-    poller.onBlockingAutoReenabled = { firedIDs = $0 }
+    poller.onBlockingRestoredAutomatically = { firedIDs = $0 }
     await poller.applyBlockingChange(enabled: false, duration: 0)
 
     // Expire the countdown while the poll's status fetch is held open: the
@@ -934,7 +934,7 @@ struct ServerStatusPollerTests {
       }
     }
     var firedIDs: Set<UUID>?
-    poller.onBlockingAutoReenabled = { firedIDs = $0 }
+    poller.onBlockingRestoredAutomatically = { firedIDs = $0 }
 
     await poller.applyBlockingChange(enabled: false, duration: 0)
     timer.countdownTick()  // expires → re-check #1 → still disabled → waits
@@ -975,7 +975,7 @@ struct ServerStatusPollerTests {
     let timer = TimerManager()
     let poller = makePollerWithTimer(timer) { _ in }
     var fired = false
-    poller.onBlockingAutoReenabled = { _ in fired = true }
+    poller.onBlockingRestoredAutomatically = { _ in fired = true }
 
     await poller.applyBlockingChange(enabled: false, duration: 0)
     timer.countdownTick()  // expires → re-check → server still disabled(60)

--- a/Sources/Holeberry/App/HoleberryApp.swift
+++ b/Sources/Holeberry/App/HoleberryApp.swift
@@ -108,6 +108,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       browserTabCoordinator: browserTabCoordinator,
       localIPAddressResolver: localIPResolver,
       updater: updaterManager.updater,
+      notificationCoordinator: notificationCoordinator,
       settingsWindowController: settingsWindowController
     )
     shortcutController = ShortcutController(

--- a/Sources/Holeberry/MenuBar/MenuBarController.swift
+++ b/Sources/Holeberry/MenuBar/MenuBarController.swift
@@ -15,6 +15,7 @@ final class MenuBarController: NSObject {
   private let browserTabCoordinator: BrowserTabCoordinator
   private let localIPAddressResolver: any LocalIPAddressProviding
   private let updater: SPUUpdater
+  private let notificationCoordinator: NotificationCoordinator
   private let defaultsSuite: UserDefaults
   private let settingsWindowController: SettingsWindowController
   private let menuBuilder = MenuBuilder()
@@ -24,10 +25,6 @@ final class MenuBarController: NSObject {
 
   // Menu lifecycle
   private var currentMenu: NSMenu?
-
-  // Inline error
-  private var errorMessage: String?
-  private var errorClearTask: Task<Void, Never>?
 
   // Browser icon cache
   private var appIconCache: [String: NSImage] = [:]
@@ -50,6 +47,7 @@ final class MenuBarController: NSObject {
     browserTabCoordinator: BrowserTabCoordinator,
     localIPAddressResolver: any LocalIPAddressProviding,
     updater: SPUUpdater,
+    notificationCoordinator: NotificationCoordinator,
     defaultsSuite: UserDefaults = .standard,
     settingsWindowController: SettingsWindowController
   ) {
@@ -60,6 +58,7 @@ final class MenuBarController: NSObject {
     self.browserTabCoordinator = browserTabCoordinator
     self.localIPAddressResolver = localIPAddressResolver
     self.updater = updater
+    self.notificationCoordinator = notificationCoordinator
     self.defaultsSuite = defaultsSuite
     self.settingsWindowController = settingsWindowController
 
@@ -128,7 +127,6 @@ final class MenuBarController: NSObject {
       showAllClients: Defaults[.showAllClientsRecentBlocked(suite: defaultsSuite)],
       showPerInstanceStats: Defaults[.showPerInstanceStats(suite: defaultsSuite)],
       durations: Defaults[.unblockDurations(suite: defaultsSuite)],
-      error: errorMessage,
       isConnected: reachability.isConnected,
       connectionStatuses: statusMonitor.connectionStatuses,
       blockingStatuses: statusMonitor.blockingStatuses,
@@ -255,9 +253,10 @@ final class MenuBarController: NSObject {
     Task {
       do {
         try await serverManager.unblock(domain: domain, duration: duration)
-        setError(nil)
       } catch {
-        showError("Failed to unblock \(domain): \(error.localizedDescription)")
+        notificationCoordinator.schedule(
+          .unblockFailed(domain: domain, error: error.localizedDescription)
+        )
       }
     }
   }
@@ -305,23 +304,6 @@ final class MenuBarController: NSObject {
 
   @objc private func checkForUpdates() {
     updater.checkForUpdates()
-  }
-
-  // MARK: - Inline Error
-
-  private func showError(_ message: String, persistent: Bool = false) {
-    setError(message, persistent: persistent)
-  }
-
-  private func setError(_ message: String?, persistent: Bool = false) {
-    errorMessage = message
-    errorClearTask?.cancel()
-    if !persistent, message != nil {
-      errorClearTask = Task { [weak self] in
-        try? await Task.sleep(for: .seconds(3))
-        self?.setError(nil)
-      }
-    }
   }
 }
 

--- a/Sources/Holeberry/MenuBar/MenuBuilder.swift
+++ b/Sources/Holeberry/MenuBar/MenuBuilder.swift
@@ -22,7 +22,6 @@ struct MenuBuilder {
     showAllClients: Bool,
     showPerInstanceStats: Bool,
     durations: [UnblockDurationEntry],
-    error: String?,
     isConnected: Bool,
     connectionStatuses: [UUID: ConnectionStatus],
     blockingStatuses: [UUID: BlockingStatus],
@@ -37,7 +36,6 @@ struct MenuBuilder {
 
     addStatusSection(
       to: menu,
-      error: error,
       isConnected: isConnected,
       servers: servers,
       querySummaries: querySummaries,
@@ -101,7 +99,6 @@ struct MenuBuilder {
   // swiftlint:disable:next function_parameter_count
   private func addStatusSection(
     to menu: NSMenu,
-    error: String?,
     isConnected: Bool,
     servers: [ServerConfig],
     querySummaries: [UUID: QuerySummary],
@@ -109,15 +106,7 @@ struct MenuBuilder {
     blockingStatuses: [UUID: BlockingStatus],
     target: MenuActionTarget
   ) {
-    if let error {
-      let item = NSMenuItem()
-      item.attributedTitle = MenuItemFactory.statusLine(
-        dotColor: .systemRed,
-        text: "⚠ \(error)"
-      )
-      item.isEnabled = false
-      menu.addItem(item)
-    } else if !isConnected {
+    if !isConnected {
       let item = NSMenuItem(title: "Disconnected", action: nil, keyEquivalent: "")
       item.isEnabled = false
       menu.addItem(item)

--- a/Sources/Holeberry/Notifications/NotificationCoordinator.swift
+++ b/Sources/Holeberry/Notifications/NotificationCoordinator.swift
@@ -22,6 +22,7 @@ final class NotificationCoordinator: NSObject {
   private static let shortcutErrorCategory = "SHORTCUT_ERROR"
   private static let unblockEndedCategory = "UNBLOCK_ENDED"
   private static let domainUnblockEndedCategory = "DOMAIN_UNBLOCK_ENDED"
+  private static let unblockFailureCategory = "UNBLOCK_FAILURE"
 
   private let defaultsSuite: UserDefaults
   private let openSettings: () -> Void
@@ -60,6 +61,8 @@ final class NotificationCoordinator: NSObject {
         : "Blocking is active again on \(serverNames.joined(separator: ", "))."
     case .domainUnblockEnded(let domain):
       content.body = "\(domain) is blocked again."
+    case .unblockFailed(let domain, let error):
+      content.body = "Failed to unblock \(domain): \(error)"
     }
 
     let request = UNNotificationRequest(
@@ -116,6 +119,9 @@ final class NotificationCoordinator: NSObject {
       return Defaults[.notifyWhenUnblockEnds(suite: defaultsSuite)]
     case .domainUnblockEnded:
       return Defaults[.notifyWhenDomainUnblockEnds(suite: defaultsSuite)]
+    case .unblockFailed:
+      // Always on — failures should never go unnoticed.
+      return true
     }
   }
 
@@ -124,6 +130,7 @@ final class NotificationCoordinator: NSObject {
     case .shortcutError: return shortcutErrorCategory
     case .unblockEnded: return unblockEndedCategory
     case .domainUnblockEnded: return domainUnblockEndedCategory
+    case .unblockFailed: return unblockFailureCategory
     }
   }
 
@@ -133,6 +140,7 @@ final class NotificationCoordinator: NSObject {
     case .shortcutError: return "shortcut-error-\(timestamp)"
     case .unblockEnded: return "unblock-ended-\(timestamp)"
     case .domainUnblockEnded: return "domain-unblock-ended-\(timestamp)"
+    case .unblockFailed: return "unblock-failed-\(timestamp)"
     }
   }
 }
@@ -146,7 +154,7 @@ extension NotificationCoordinator: @preconcurrency UNUserNotificationCenterDeleg
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
   ) {
     switch notification.request.content.categoryIdentifier {
-    case Self.shortcutErrorCategory:
+    case Self.shortcutErrorCategory, Self.unblockFailureCategory:
       // An action the user triggered failed — alert them.
       completionHandler([.banner, .sound])
     default:

--- a/Sources/Holeberry/Notifications/UnblockEndedNotifier.swift
+++ b/Sources/Holeberry/Notifications/UnblockEndedNotifier.swift
@@ -4,7 +4,7 @@ import HoleberryCore
 /// Bridges core unblock-end events to `NotificationCoordinator`.
 ///
 /// The global-unblock event arrives as a typed closure on `ServerStatusPoller`
-/// (`onBlockingAutoReenabled`) — the poller is created in the composition root,
+/// (`onBlockingRestoredAutomatically`) — the poller is created in the composition root,
 /// so it can be wired directly. The domain-unblock event arrives as a
 /// `.domainUnblockExpired` NotificationCenter post, because the decorator that
 /// posts it is created deep inside `PiholeServerManager`. Both become
@@ -35,7 +35,7 @@ final class UnblockEndedNotifier {
     self.notificationCoordinator = notificationCoordinator
     self.notificationCenter = notificationCenter
 
-    statusMonitor.onBlockingAutoReenabled = { [weak self] serverIDs in
+    statusMonitor.onBlockingRestoredAutomatically = { [weak self] serverIDs in
       self?.notifyUnblockEnded(serverIDs: serverIDs)
     }
 

--- a/Sources/Holeberry/Notifications/UserNotificationKind.swift
+++ b/Sources/Holeberry/Notifications/UserNotificationKind.swift
@@ -15,4 +15,7 @@ enum UserNotificationKind {
 
   /// A temporary unblock for a specific domain expired on its own.
   case domainUnblockEnded(domain: String)
+
+  /// A temporary unblock of a domain failed.
+  case unblockFailed(domain: String, error: String)
 }


### PR DESCRIPTION
## Summary

Temporary-unblock failures currently surface as a red inline error row in the menu bar, which:

- is static and hides the live status rows for the 3s it is shown
- has no dismiss or retry affordance
- can be missed entirely when the menu is closed

This PR routes temp-unblock failures through the always-on notification path instead.

## Changes

- New `UserNotificationKind.unblockFailed(domain:error:)` — "Failed to unblock <domain>: <error>", banner + sound, `UNBLOCK_FAILURE` category, always-on regardless of notification settings
- `MenuBarController`: drop the inline error state (`errorMessage` / `errorClearTask` / `showError` / `setError`) and schedule the failure notification, with `NotificationCoordinator` injected from the composition root
- `MenuBuilder`: remove the error status row from the menu
- Rename `ServerStatusPoller.onBlockingAutoReenabled` → `onBlockingRestoredAutomatically` (the callback also fires for the end-of-unblock transition, not just a timed re-enable); tests and `UnblockEndedNotifier` updated to match

## Testing

- `swift test` (HoleberryCore): 374 tests in 46 suites — all pass
- `swiftlint --strict`: 0 violations
- `swift-format lint --recursive --strict`: clean
