### PR TITLE
fix: replace Task.sleep(for:) with a shared sleepForSeconds helper

### DIFF
--- a/Packages/HoleberryCore/Sources/HoleberryCore/Networking/RetryPolicy.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Networking/RetryPolicy.swift
@@ -43,13 +43,16 @@ extension RetryPolicy {
 /// Execute an operation with retry according to the given policy.
 /// - Parameters:
 ///   - policy: The retry policy to follow.
-///   - sleep: The sleep function (injectable for testing). Defaults to `Task.sleep`.
+///   - sleep: The sleep function (injectable for testing). Defaults to
+///     `ContinuousClock().sleep(for:)` — `Task.sleep(for:)` is avoided because its
+///     cross-module inlining can hit a Swift 6.3 task-allocator crash.
+///     Revisit when the toolchain issue is fixed.
 ///   - operation: The throwing async operation to retry.
 /// - Returns: The operation's result on success.
 /// - Throws: The last error if all attempts fail or the error is not retryable.
 public func withRetry<T: Sendable>(
   _ policy: RetryPolicy,
-  sleep: @Sendable @escaping (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
+  sleep: @Sendable @escaping (Duration) async throws -> Void = { try await ContinuousClock().sleep(for: $0) },
   operation: @Sendable () async throws -> T
 ) async throws -> T {
   for attempt in 0..<policy.maxAttempts {

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/TemporaryUnblockPiholeServiceDecorator.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/Pihole/TemporaryUnblockPiholeServiceDecorator.swift
@@ -39,7 +39,7 @@ public final class TemporaryUnblockPiholeServiceDecorator: PiholeServiceCommentA
     backoffIntervals: [TimeInterval] = [10, 30, 120, 600],
     defaultsSuite: UserDefaults = .standard,
     notificationCenter: NotificationCenter = .default,
-    sleep: @escaping (TimeInterval) async throws -> Void = { try await Task.sleep(for: .seconds($0)) }
+    sleep: @escaping (TimeInterval) async throws -> Void = { try await sleepForSeconds($0) }
   ) {
     self.wrapped = service
     self.backoffIntervals = backoffIntervals

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Services/TaskPollScheduler.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Services/TaskPollScheduler.swift
@@ -36,7 +36,7 @@ public final class TaskPollScheduler: PollScheduler {
       while !Task.isCancelled {
         guard self != nil else { return }
         await onTick()
-        try? await Task.sleep(for: .seconds(interval))
+        try? await sleepForSeconds(interval)
       }
     }
   }

--- a/Packages/HoleberryCore/Sources/HoleberryCore/Utils/Sleep.swift
+++ b/Packages/HoleberryCore/Sources/HoleberryCore/Utils/Sleep.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Suspends via `Task.sleep(nanoseconds:)` — `Task.sleep(for:)` crashes with
+/// cross-module inlining on Swift 6.3; revisit when fixed. Negatives clamp.
+public func sleepForSeconds(_ seconds: TimeInterval) async throws {
+  try await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+}

--- a/Sources/Holeberry/App/HoleberryApp.swift
+++ b/Sources/Holeberry/App/HoleberryApp.swift
@@ -131,7 +131,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             await self.serverManager.logoutAll()
           }
           group.addTask {
-            try await Task.sleep(for: .seconds(5))
+            try await sleepForSeconds(5)
           }
           _ = try await group.next()
           group.cancelAll()

--- a/Sources/Holeberry/Settings/ConnectionViews/ConnectionSheet.swift
+++ b/Sources/Holeberry/Settings/ConnectionViews/ConnectionSheet.swift
@@ -469,7 +469,7 @@ func withThrowingTimeout<T: Sendable>(
       try await operation()
     }
     group.addTask {
-      try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+      try await sleepForSeconds(seconds)
       throw TimeoutError()
     }
     guard let result = try await group.next() else {


### PR DESCRIPTION
## Summary

`Task.sleep(for:)` can hit a Swift 6.3 task-allocator crash when the call is inlined across module boundaries. This PR centralizes a `Task.sleep(nanoseconds:)`-based workaround in a shared `sleepForSeconds(_:)` helper in HoleberryCore and replaces the affected call sites.

## Changes

- Add `sleepForSeconds(_:)` to `Packages/HoleberryCore/Sources/HoleberryCore/Utils/Sleep.swift` — suspends via `Task.sleep(nanoseconds:)` (clamping negatives to 0) to avoid the cross-module-inlining crash; documented with a "revisit when fixed" note.
- Replace `Task.sleep(for:)` call sites:
  - `TaskPollScheduler`
  - `TemporaryUnblockPiholeServiceDecorator`
  - `HoleberryApp` (app target)
  - `ConnectionSheet.withThrowingTimeout` (app target)
- In `RetryPolicy.withRetry`, default the injectable sleep closure to `ContinuousClock().sleep(for:)` instead of `Task.sleep(for:)`, with a doc comment explaining the reason and to revisit when the toolchain issue is fixed.

## Existing PRs

Searched open and closed PRs for related work (sleep / Swift 6.3 / crash) — none address this; no duplicates.

## Testing

- Core tests: `swift test` in `Packages/HoleberryCore` — **374 tests in 46 suites passed**.
- `swiftlint --strict Sources/ Packages/HoleberryCore/Sources/` — 0 violations.
- `swift-format lint --recursive --strict Sources/ Packages/HoleberryCore/Sources/` — clean.
