### PR TITLE
feat: show gravity last-updated row for v5-only setups

### DIFF
--- a/Sources/Holeberry/MenuBar/GravityMenuState.swift
+++ b/Sources/Holeberry/MenuBar/GravityMenuState.swift
@@ -4,6 +4,9 @@ import Foundation
 enum GravityMenuState {
   /// The section is hidden (user disabled it in settings).
   case hidden
+  /// No configured instance can trigger a gravity update via its API (e.g.
+  /// only Pi-hole v5 instances); show a disabled "last updated" row instead.
+  case noUpdateCapableInstances
   /// A gravity update is in flight; show a spinner row.
   case updating
   /// Ready to trigger an update; carries app-observed completion timestamps.

--- a/Sources/Holeberry/MenuBar/MenuBarController.swift
+++ b/Sources/Holeberry/MenuBar/MenuBarController.swift
@@ -96,8 +96,8 @@ final class MenuBarController: NSObject {
     let gravityState: GravityMenuState
     if !Defaults[.showGravityMenuItem(suite: defaultsSuite)] {
       gravityState = .hidden
-    } else if serverManager.servers.contains(where: { $0.version == .v5 }),
-      !serverManager.servers.contains(where: { $0.version == .v6 })
+    } else if !serverManager.servers.isEmpty,
+      serverManager.servers.allSatisfy({ $0.version == .v5 })
     {
       // No instance can update gravity via the API (v5-only); show a
       // "last updated" row instead.

--- a/Sources/Holeberry/MenuBar/MenuBarController.swift
+++ b/Sources/Holeberry/MenuBar/MenuBarController.swift
@@ -96,6 +96,12 @@ final class MenuBarController: NSObject {
     let gravityState: GravityMenuState
     if !Defaults[.showGravityMenuItem(suite: defaultsSuite)] {
       gravityState = .hidden
+    } else if serverManager.servers.contains(where: { $0.version == .v5 }),
+      !serverManager.servers.contains(where: { $0.version == .v6 })
+    {
+      // No instance can update gravity via the API (v5-only); show a
+      // "last updated" row instead.
+      gravityState = .noUpdateCapableInstances
     } else if statusMonitor.isGravityUpdating {
       gravityState = .updating
     } else {

--- a/Sources/Holeberry/MenuBar/MenuBuilder.swift
+++ b/Sources/Holeberry/MenuBar/MenuBuilder.swift
@@ -381,7 +381,7 @@ struct MenuBuilder {
     spinner.usesThreadedAnimation = true
     spinner.startAnimation(nil)
 
-    let label = NSTextField(labelWithString: "Updating gravity…")
+    let label = NSTextField(labelWithString: "Updating Gravity…")
     label.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
     label.textColor = .disabledControlTextColor
 

--- a/Sources/Holeberry/MenuBar/MenuBuilder.swift
+++ b/Sources/Holeberry/MenuBar/MenuBuilder.swift
@@ -312,17 +312,29 @@ struct MenuBuilder {
     target: MenuActionTarget
   ) {
     let v6Servers = servers.filter { $0.version == .v6 }
-    guard !v6Servers.isEmpty else { return }
 
     switch gravityState {
     case .hidden:
       return
+
+    case .noUpdateCapableInstances:
+      guard servers.contains(where: { $0.version == .v5 }) else { return }
+      menu.addItem(.separator())
+      menu.addItem(
+        makeGravityLastUpdatedItem(
+          servers: servers,
+          connectionStatuses: connectionStatuses,
+          querySummaries: querySummaries
+        )
+      )
 
     case .updating:
       menu.addItem(.separator())
       menu.addItem(makeGravityUpdatingItem())
 
     case .ready(let completedAt):
+      guard !v6Servers.isEmpty else { return }
+
       menu.addItem(.separator())
 
       let connectedV6 = v6Servers.filter { connectionStatuses[$0.id] == .connected }
@@ -391,14 +403,34 @@ struct MenuBuilder {
     return item
   }
 
+  /// Disabled row for setups with only Pi-hole v5 instances: the API can't
+  /// trigger a gravity update, so show when gravity was last updated instead.
+  private func makeGravityLastUpdatedItem(
+    servers: [ServerConfig],
+    connectionStatuses: [UUID: ConnectionStatus],
+    querySummaries: [UUID: QuerySummary]
+  ) -> NSMenuItem {
+    let connectedV5 = servers.filter { $0.version == .v5 && connectionStatuses[$0.id] == .connected }
+    // Show the stalest server: the oldest "last updated" date = the max age.
+    let stalestDate = connectedV5.compactMap { querySummaries[$0.id]?.gravityLastUpdated }.min()
+
+    let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+    item.isEnabled = false
+    item.title = gravityLastUpdatedTitle(maxAge: stalestDate, showAtMost: connectedV5.count > 1)
+    item.setAccessibilityLabel("Gravity last updated")
+    return item
+  }
+
+  /// "Gravity last updated <relative> ago"; "at most" for several servers,
+  /// never for "a few moments ago"; "unknown" when no timestamp is available.
+  private func gravityLastUpdatedTitle(maxAge: Date?, showAtMost: Bool) -> String {
+    guard let maxAge else { return "Gravity last updated: unknown" }
+    return "Gravity last updated \(gravityRelativeText(maxAge: maxAge, showAtMost: showAtMost))"
+  }
+
   /// "Update Gravity" over "Gravity updated <relative> ago"; "at most" for
   /// several servers, never for "a few moments ago".
   private func gravityAttributedTitle(maxAge: Date, showAtMost: Bool) -> NSAttributedString {
-    // Fresh timestamps use the fixed wording until the next poll lands.
-    let isMomentsAgo = Date().timeIntervalSince(maxAge) < 60
-    let relative = isMomentsAgo ? "a few moments ago" : MenuItemFactory.relativeTimestamp(since: maxAge)
-    let prefix = isMomentsAgo ? "" : (showAtMost ? "at most " : "")
-
     let result = NSMutableAttributedString()
     result.append(
       NSAttributedString(
@@ -412,7 +444,7 @@ struct MenuBuilder {
     result.append(NSAttributedString(string: "\n"))
     result.append(
       NSAttributedString(
-        string: "Updated \(prefix)\(relative)",
+        string: "Updated \(gravityRelativeText(maxAge: maxAge, showAtMost: showAtMost))",
         attributes: [
           .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
           .foregroundColor: NSColor.secondaryLabelColor
@@ -420,6 +452,15 @@ struct MenuBuilder {
       )
     )
     return result
+  }
+
+  /// "a few moments ago" until the next poll lands; "at most " only for
+  /// several servers, never alongside "a few moments ago".
+  private func gravityRelativeText(maxAge: Date, showAtMost: Bool) -> String {
+    let isMomentsAgo = Date().timeIntervalSince(maxAge) < 60
+    let relative = isMomentsAgo ? "a few moments ago" : MenuItemFactory.relativeTimestamp(since: maxAge)
+    let prefix = isMomentsAgo ? "" : (showAtMost ? "at most " : "")
+    return "\(prefix)\(relative)"
   }
 
   private func addDisableDurationItem(

--- a/Sources/Holeberry/MenuBar/MenuBuilder.swift
+++ b/Sources/Holeberry/MenuBar/MenuBuilder.swift
@@ -318,7 +318,6 @@ struct MenuBuilder {
       return
 
     case .noUpdateCapableInstances:
-      guard servers.contains(where: { $0.version == .v5 }) else { return }
       menu.addItem(.separator())
       menu.addItem(
         makeGravityLastUpdatedItem(
@@ -403,20 +402,20 @@ struct MenuBuilder {
     return item
   }
 
-  /// Disabled row for setups with only Pi-hole v5 instances: the API can't
-  /// trigger a gravity update, so show when gravity was last updated instead.
+  /// Disabled row for instances that can't trigger a gravity update via
+  /// their API; show when gravity was last updated instead.
   private func makeGravityLastUpdatedItem(
     servers: [ServerConfig],
     connectionStatuses: [UUID: ConnectionStatus],
     querySummaries: [UUID: QuerySummary]
   ) -> NSMenuItem {
-    let connectedV5 = servers.filter { $0.version == .v5 && connectionStatuses[$0.id] == .connected }
+    let connected = servers.filter { connectionStatuses[$0.id] == .connected }
     // Show the stalest server: the oldest "last updated" date = the max age.
-    let stalestDate = connectedV5.compactMap { querySummaries[$0.id]?.gravityLastUpdated }.min()
+    let stalestDate = connected.compactMap { querySummaries[$0.id]?.gravityLastUpdated }.min()
 
     let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
     item.isEnabled = false
-    item.title = gravityLastUpdatedTitle(maxAge: stalestDate, showAtMost: connectedV5.count > 1)
+    item.title = gravityLastUpdatedTitle(maxAge: stalestDate, showAtMost: connected.count > 1)
     item.setAccessibilityLabel("Gravity last updated")
     return item
   }

--- a/Sources/Holeberry/Notifications/NotificationCoordinator.swift
+++ b/Sources/Holeberry/Notifications/NotificationCoordinator.swift
@@ -65,12 +65,9 @@ final class NotificationCoordinator: NSObject {
       content.body = "\(domain) is blocked again."
     case .gravityUpdateCompleted:
       content.body = "Gravity updated."
-    case .gravityUpdatePartiallyCompleted(let failures):
+    case .gravityUpdatePartiallyCompleted(let failure):
       content.body = "Gravity partially updated."
-      content.subtitle =
-        failures
-        .map { "Server \($0.serverName) failed with \($0.category)" }
-        .joined(separator: "\n")
+      content.subtitle = "Server \(failure.serverName) failed with \(failure.category)"
     case .gravityUpdateFailedAll:
       content.body = "Gravity failed to update for all servers."
       content.subtitle = "Check your servers' connectivity."
@@ -95,8 +92,8 @@ final class NotificationCoordinator: NSObject {
   // MARK: - Gravity outcomes
 
   /// Schedules one aggregated notification for a gravity run: a completion
-  /// banner when every server succeeded, a partial banner naming the failures
-  /// when some did, and a failure banner when none did.
+  /// banner when every server succeeded, a partial banner naming the failed
+  /// server when some did, and a failure banner when none did.
   func scheduleGravityOutcomeNotifications(
     _ outcomes: [UUID: GravityUpdateOutcome],
     labelFor: (UUID) -> String?
@@ -113,7 +110,8 @@ final class NotificationCoordinator: NSObject {
       return
     }
 
-    let failures = outcomes.compactMap { id, outcome -> (serverName: String, category: String)? in
+    // With the 2-server cap, a partial run has exactly one non-succeeded server.
+    let failure = outcomes.compactMap { id, outcome -> (serverName: String, category: String)? in
       switch outcome {
       case .succeeded:
         return nil
@@ -122,8 +120,10 @@ final class NotificationCoordinator: NSObject {
       case .failed(let error):
         return (labelFor(id) ?? "Pi-hole", error.gravityErrorCategory)
       }
+    }.first
+    if let failure {
+      schedule(.gravityUpdatePartiallyCompleted(failure: failure))
     }
-    schedule(.gravityUpdatePartiallyCompleted(failures: failures))
   }
 
   // MARK: - Authorization

--- a/Sources/Holeberry/Notifications/UserNotificationKind.swift
+++ b/Sources/Holeberry/Notifications/UserNotificationKind.swift
@@ -19,9 +19,9 @@ enum UserNotificationKind {
   /// A gravity update finished successfully on every server.
   case gravityUpdateCompleted
 
-  /// Some servers updated, others did not; names the failed servers and the
-  /// category of their error.
-  case gravityUpdatePartiallyCompleted(failures: [(serverName: String, category: String)])
+  /// Some servers updated, others did not; names the failed server and its
+  /// error category.
+  case gravityUpdatePartiallyCompleted(failure: (serverName: String, category: String))
 
   /// No server updated.
   case gravityUpdateFailedAll

--- a/Sources/Holeberry/Settings/SettingsView.swift
+++ b/Sources/Holeberry/Settings/SettingsView.swift
@@ -208,9 +208,18 @@ struct SettingsView: View {
 
     Section("Gravity") {
       VStack(alignment: .leading) {
-        Toggle("Show \"Update Gravity\" in main menu", isOn: $showGravityMenuItem)
+        Toggle("Show gravity update in main menu", isOn: $showGravityMenuItem)
 
-        Text("The Update Gravity shortcut still works when this is off.")
+        Text(
+          "Pi-hole v6 instances show an \"Update Gravity\" item. "
+            + "With only Pi-hole v5 instances, the menu shows when gravity "
+            + "was last updated instead — v5 can't update gravity via the API."
+        )
+        .font(.callout)
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Text("The Update Gravity shortcut still works when this is off (v6 only).")
           .font(.callout)
           .foregroundColor(.secondary)
           .fixedSize(horizontal: false, vertical: true)

--- a/Sources/Holeberry/Settings/SettingsView.swift
+++ b/Sources/Holeberry/Settings/SettingsView.swift
@@ -181,7 +181,7 @@ struct SettingsView: View {
       if launchAtLogin {
         HStack(spacing: 4) {
           if requiresApproval {
-            Text("Approval needed —")
+            Text("Approval needed: ")
               .font(.caption)
               .foregroundColor(.secondary)
           }
@@ -208,17 +208,16 @@ struct SettingsView: View {
 
     Section("Gravity") {
       VStack(alignment: .leading) {
-        Toggle("Show gravity update in main menu", isOn: $showGravityMenuItem)
+        Toggle("Show Gravity update in menu bar", isOn: $showGravityMenuItem)
 
         Text(
-          "Pi-hole v6 shows an \"Update Gravity\" item; v5-only setups show the "
-            + "last gravity update time."
+          "Not available for v5-only setups (API limitation), shows last update time instead."
         )
         .font(.callout)
         .foregroundColor(.secondary)
         .fixedSize(horizontal: false, vertical: true)
 
-        Text("The Update Gravity shortcut still works when this is off (v6 only).")
+        Text("Shortcut still works regardless of this setting.")
           .font(.callout)
           .foregroundColor(.secondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -264,7 +263,7 @@ struct SettingsView: View {
         }
       }
 
-      KeyboardShortcuts.Recorder("Update Gravity:", name: .updateGravity)
+      KeyboardShortcuts.Recorder("Update Gravity (v6-only):", name: .updateGravity)
     } header: {
       Text("Global Shortcuts")
       Text(
@@ -280,7 +279,7 @@ struct SettingsView: View {
     Section {
       ForEach(durations) { entry in
         KeyboardShortcuts.Recorder(
-          "Disable \(UnblockDurationFormatter.string(from: entry.seconds)):",
+          "Disable for \(UnblockDurationFormatter.string(from: entry.seconds)):",
           name: KeyboardShortcuts.Name.durationShortcutName(for: entry)
         )
       }

--- a/Sources/Holeberry/Settings/SettingsView.swift
+++ b/Sources/Holeberry/Settings/SettingsView.swift
@@ -211,9 +211,8 @@ struct SettingsView: View {
         Toggle("Show gravity update in main menu", isOn: $showGravityMenuItem)
 
         Text(
-          "Pi-hole v6 instances show an \"Update Gravity\" item. "
-            + "With only Pi-hole v5 instances, the menu shows when gravity "
-            + "was last updated instead — v5 can't update gravity via the API."
+          "Pi-hole v6 shows an \"Update Gravity\" item; v5-only setups show the "
+            + "last gravity update time."
         )
         .font(.callout)
         .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary

When only Pi-hole v5 instances are configured, the Pi-hole v5 API cannot trigger a gravity update. Previously Holeberry hid the gravity section of the main menu in that case; now it shows a disabled row with the last gravity update time instead — so v5-only users still get visibility into the state of their gravity lists without a dead-end menu.

The change also:

- Replaces the version-specific hidden/action decision with an explicit `GravityMenuState.noUpdateCapableInstances` state (decoupled from the v5 implementation detail).
- Updates the Gravity section in Settings so the toggle and its description match the new behavior, and labels the Update Gravity shortcut as v6-only.

## Behavior

- **v5-only setups:** disabled row — `Gravity last updated X ago` (1 connected instance), `Gravity last updated at most X ago` (2+ connected instances, stalest timestamp), `Gravity last updated: unknown` when no timestamp is available.
- **v6 / mixed setups:** unchanged (`Update Gravity` item + subtext, spinner while updating).
- **Shortcut:** still a no-op without a connected v6 instance; `PiholeV5Service.updateGravity()` still reports `.unsupported`; notifications unchanged.

## Related PRs

Follow-up to #17 ("feat: update Gravity from the menu bar", merged). No other open or closed PRs address this area.

## Files

- `Sources/Holeberry/MenuBar/GravityMenuState.swift`, `MenuBarController.swift`, `MenuBuilder.swift` — menu state + v5-only row rendering.
- `Sources/Holeberry/Settings/SettingsView.swift` — Gravity toggle/description copy.
- `Sources/Holeberry/Notifications/UserNotificationKind.swift`, `NotificationCoordinator.swift` — `gravityUpdatePartiallyCompleted` now carries a single failure tuple (the 2-server cap makes a partial run always have exactly one non-succeeded server).

## Testing

- `swiftlint --strict Sources/ Packages/HoleberryCore/Sources/` — 0 violations
- `swift-format lint --recursive --strict` — clean
- `swift test` (HoleberryCore) — 407 tests in 47 suites passed
- `xcodebuild -scheme Holeberry` (CODE_SIGNING_ALLOWED=NO) — BUILD SUCCEEDED
- No app-target test bundle exists; the menu row is verified by build, lint, and manual/type-level review.
